### PR TITLE
fix: serve uploaded files via API route to support production builds

### DIFF
--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -27,7 +27,7 @@ app/
 content/vulnerabilities/  # Markdown docs for each vulnerability
 lib/                      # Utilities (api, auth, prisma, types)
 prisma/                   # Schema and seed data with CTF flags
-public/uploads/           # User-uploaded files
+uploads/                  # User-uploaded files (served via /api/uploads/)
 docs/                     # Astro documentation site (separate npm project)
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,5 @@ prisma/*.db
 prisma/*.db-journal
 
 # uploads
-public/uploads/*
+uploads/*
 documents/invoices/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ app/
 content/vulnerabilities/    # Markdown files for each vulnerability
 lib/                        # Utilities (api, auth, prisma, types)
 prisma/                     # Schema and seed.ts with CTF flags
-public/uploads/             # User-uploaded files
+uploads/                    # User-uploaded files (served via /api/uploads/)
 docs/                       # Astro documentation site (separate npm project)
 hall-of-fame/data.json      # Hall of Fame entries (community-driven via PRs)
 ```

--- a/app/admin/products/ProductsManagementClient.tsx
+++ b/app/admin/products/ProductsManagementClient.tsx
@@ -260,7 +260,7 @@ export default function ProductsManagementClient() {
                   className="relative aspect-square cursor-pointer overflow-hidden bg-slate-100 dark:bg-slate-700"
                   onClick={() => openPreview(product.imageUrl)}
                 >
-                  {product.imageUrl.startsWith("/uploads/") ? (
+                  {product.imageUrl.startsWith("/api/uploads/") ? (
                     <object
                       data={product.imageUrl}
                       type="image/svg+xml"
@@ -343,7 +343,7 @@ export default function ProductsManagementClient() {
                 />
               </svg>
             </button>
-            {previewUrl.startsWith("/uploads/") ? (
+            {previewUrl.startsWith("/api/uploads/") ? (
               <object
                 data={previewUrl}
                 type="image/svg+xml"

--- a/app/api/admin/products/[id]/image/route.ts
+++ b/app/api/admin/products/[id]/image/route.ts
@@ -78,7 +78,7 @@ export async function POST(
       );
     }
 
-    const uploadsDir = join(process.cwd(), "public", "uploads");
+    const uploadsDir = join(process.cwd(), "uploads");
     if (!existsSync(uploadsDir)) {
       await mkdir(uploadsDir, { recursive: true });
     }
@@ -91,7 +91,7 @@ export async function POST(
     const filepath = join(uploadsDir, filename);
     await writeFile(filepath, buffer);
 
-    const imageUrl = `/uploads/${filename}`;
+    const imageUrl = `/api/uploads/${filename}`;
 
     await prisma.product.update({
       where: { id },

--- a/app/api/uploads/[...path]/route.ts
+++ b/app/api/uploads/[...path]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+
+const MIME_TYPES: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+};
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const filename = path.join("/");
+
+  if (filename.includes("..") || filename.includes("\0")) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  const filepath = join(process.cwd(), "uploads", filename);
+
+  if (!existsSync(filepath)) {
+    return NextResponse.json({ error: "File not found" }, { status: 404 });
+  }
+
+  const ext = filename.substring(filename.lastIndexOf(".")).toLowerCase();
+  const contentType = MIME_TYPES[ext];
+
+  if (!contentType) {
+    return NextResponse.json(
+      { error: "Unsupported file type" },
+      { status: 400 }
+    );
+  }
+
+  const fileBuffer = await readFile(filepath);
+
+  return new NextResponse(fileBuffer, {
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+}

--- a/app/products/[id]/ProductDetailClient.tsx
+++ b/app/products/[id]/ProductDetailClient.tsx
@@ -159,7 +159,7 @@ export default function ProductDetailClient({
         <div className="space-y-6">
           <div className="overflow-hidden rounded-2xl bg-white shadow-sm dark:bg-slate-800">
             <div className="relative aspect-square w-full overflow-hidden bg-slate-100 dark:bg-slate-700">
-              {product.imageUrl.startsWith("/uploads/") &&
+              {product.imageUrl.startsWith("/api/uploads/") &&
               product.imageUrl.endsWith(".svg") ? (
                 <object
                   data={product.imageUrl}

--- a/content/vulnerabilities/malicious-file-upload.md
+++ b/content/vulnerabilities/malicious-file-upload.md
@@ -26,7 +26,7 @@ In this application, the admin product image upload feature is vulnerable to mal
 1. **Content-Type validation only** - The server only checks the `Content-Type` header, which can be spoofed
 2. **No content inspection** - The actual file contents are not validated
 3. **SVG files allowed** - SVG files can contain `<script>` tags and event handlers
-4. **Direct file serving** - Uploaded files are served directly from the public directory
+4. **Direct file serving** - Uploaded files are served directly without sanitization
 
 ### Vulnerable Code
 
@@ -57,7 +57,7 @@ The vulnerability is amplified because the product detail page renders SVG image
 
 ```typescript
 // Using <object> tag renders SVG with JavaScript execution in user browsers
-{product.imageUrl.startsWith("/uploads/") &&
+{product.imageUrl.startsWith("/api/uploads/") &&
 product.imageUrl.endsWith(".svg") ? (
   <object
     data={product.imageUrl}
@@ -128,7 +128,7 @@ To retrieve the flag, you need to:
 After uploading, the malicious SVG is stored on the server and will be triggered whenever the product is viewed:
 
 - **Product Detail Page:** Any user visiting `/products/[product-id]` will trigger the XSS
-- **Direct URL Access:** Visit `/uploads/[product-id]-[timestamp]-malicious.svg` directly
+- **Direct URL Access:** Visit `/api/uploads/[product-id]-[timestamp]-malicious.svg` directly
 - **Admin Panel Preview:** Click on the product image in the admin panel
 - **Product Catalog:** Users browsing the homepage or product listings will see the compromised product
 
@@ -169,7 +169,7 @@ if (file.type === "image/svg+xml") {
 // In next.config.js or server configuration
 headers: [
   {
-    source: "/uploads/:path*",
+    source: "/api/uploads/:path*",
     headers: [
       { key: "Content-Security-Policy", value: "script-src 'none'" },
       { key: "X-Content-Type-Options", value: "nosniff" },

--- a/docs/src/data/blog/malicious-file-upload-stored-xss.md
+++ b/docs/src/data/blog/malicious-file-upload-stored-xss.md
@@ -2,7 +2,7 @@
 author: kOaDT
 authorGithubUrl: https://github.com/kOaDT
 authorGithubAvatar: https://avatars.githubusercontent.com/u/17499022?v=4
-pubDatetime: 2026-01-24T19:00:00Z
+pubDatetime: 2026-02-07T18:34:00Z
 title: "Malicious File Upload: Stored XSS via SVG"
 slug: malicious-file-upload-stored-xss
 draft: false
@@ -93,7 +93,7 @@ The malicious script executes in multiple contexts:
 
 - **Product detail page**: Navigate to `http://localhost:3000/products/[product-id]` as any user
 - **Admin panel preview**: View the product in the admin interface
-- **Direct file access**: Access the uploaded file at `/uploads/[filename].svg`
+- **Direct file access**: Access the uploaded file at `/api/uploads/[filename].svg`
 
 When the page loads, the browser parses the SVG and executes the embedded JavaScript, displaying the alert dialog.
 
@@ -190,7 +190,7 @@ Configure the server to serve uploaded files with security headers that prevent 
 // next.config.js
 headers: [
   {
-    source: "/uploads/:path*",
+    source: "/api/uploads/:path*",
     headers: [
       { key: "Content-Security-Policy", value: "script-src 'none'" },
       { key: "X-Content-Type-Options", value: "nosniff" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2449,6 +2450,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2514,6 +2516,7 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3019,6 +3022,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3399,6 +3403,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4342,6 +4347,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4442,6 +4448,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4543,6 +4550,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8190,6 +8198,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8219,6 +8228,7 @@
       "integrity": "sha512-XRfmGzh6gtkc/Vq3LqZJcS2884dQQW3UhPo6jNRoiTW95FFQkXFg8vkYEy6og+Pyv0aY7zRQ7Wn1Cvr56XjhQQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.1",
         "@prisma/engines": "6.19.1"
@@ -8322,6 +8332,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8331,6 +8342,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9284,7 +9296,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -9356,6 +9369,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9558,6 +9572,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10034,6 +10049,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Replace public/uploads/ with dynamic /api/uploads/ route to ensure uploaded files are served correctly in production mode (npm start). Previously, files uploaded after build time returned HTTP 404 until server restart.

- Create /api/uploads/[...path] route for dynamic file serving
- Move upload directory from public/uploads/ to uploads/
- Update all file references and documentation
- Add path traversal protection and proper MIME type handling

Issue: https://github.com/kOaDT/oss-oopssec-store/issues/48