### PR TITLE
feat: add Docker Hub auto-publish workflow and update docs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,24 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/oss-oopssec-store:${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/oss-oopssec-store:latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
   <a href="https://github.com/kOaDT/oss-oopssec-store/blob/main/CONTRIBUTING.md">Contributing</a> |
   <a href="https://github.com/users/kOaDT/projects/3">Roadmap</a> |
   <a href="https://github.com/users/kOaDT/projects/3/views/6">Good first issues</a> |
-  <a href="https://kOaDT.github.io/oss-oopssec-store">Walkthroughs</a>
+  <a href="https://kOaDT.github.io/oss-oopssec-store">Walkthroughs</a> |
+  <a href="https://hub.docker.com/r/leogra/oss-oopssec-store">Docker Hub</a>
 </p>
 
 <div align="center">
@@ -108,7 +109,21 @@ This creates the `.env` file, installs dependencies, sets up the SQLite database
 
 ### Docker
 
-No Node.js required. Just [Docker](https://docs.docker.com/get-docker/):
+No Node.js required. Just [Docker](https://docs.docker.com/get-docker/).
+
+#### From Docker Hub (quickest)
+
+```bash
+docker run -p 3000:3000 leogra/oss-oopssec-store
+```
+
+To persist data across restarts:
+
+```bash
+docker run -p 3000:3000 -v oss-data:/app/data leogra/oss-oopssec-store
+```
+
+#### From source (Docker Compose)
 
 ```bash
 git clone https://github.com/kOaDT/oss-oopssec-store.git


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow that automatically builds and pushes the Docker image to Docker Hub on every release. Update README with Docker Hub quick start instructions and link.

## Type of change

- [ ] Bug fix
- [x] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [x] Documentation update
- [ ] Other (please describe):

## Testing done

- Docker image built and pushed manually to `leogra/oss-oopssec-store:2.9.0` to verify Dockerfile works
- Workflow will be validated on next GitHub release

## Checklist

- [x] Documentation updated (if applicable)

### If adding a new vulnerability

- [ ] Flag added in `prisma/seed.ts` with format `OSS{...}`
- [ ] Three progressive hints added in `prisma/seed.ts`
- [ ] Vulnerable code path is exploitable and demonstrable
- [ ] Markdown documentation added under `content/vulnerabilities/`
- [ ] Regression tests added (unit, API, and/or E2E)
- [ ] No real-world secrets introduced
