### PR TITLE
test: add business logic tests (unit, API, E2E)

### DIFF
--- a/cypress/e2e/business/auth.cy.ts
+++ b/cypress/e2e/business/auth.cy.ts
@@ -1,0 +1,90 @@
+describe("Authentication (E2E)", () => {
+  describe("Login", () => {
+    it("logs in with valid credentials and redirects to home", () => {
+      cy.visit("/login");
+
+      cy.get("input#email").type("alice@example.com");
+      cy.get("input#password").type("iloveduck");
+      cy.get("form").submit();
+
+      cy.url({ timeout: 10000 }).should("not.include", "/login");
+      cy.url().should("eq", Cypress.config().baseUrl + "/");
+    });
+
+    it("shows error for invalid credentials", () => {
+      cy.visit("/login");
+
+      cy.get("input#email").type("alice@example.com");
+      cy.get("input#password").type("wrongpassword");
+      cy.get("form").submit();
+
+      cy.get(".border-red-200").should("be.visible");
+      cy.url().should("include", "/login");
+    });
+
+    it("admin login redirects to /admin", () => {
+      cy.visit("/login");
+
+      cy.get("input#email").type("admin@oss.com");
+      cy.get("input#password").type("admin");
+      cy.get("form").submit();
+
+      cy.url({ timeout: 10000 }).should("include", "/admin");
+    });
+  });
+
+  describe("Signup", () => {
+    it("creates a new account and redirects to home", () => {
+      const email = `e2e-${Date.now()}@example.com`;
+
+      cy.visit("/signup");
+
+      cy.get("input#email").type(email);
+      cy.get("input#password").type("securepass123");
+      cy.get("input#passwordConfirmation").type("securepass123");
+      cy.get("form").submit();
+
+      cy.url({ timeout: 10000 }).should("not.include", "/signup");
+    });
+
+    it("shows error when passwords do not match", () => {
+      cy.visit("/signup");
+
+      cy.get("input#email").type("mismatch@example.com");
+      cy.get("input#password").type("password1");
+      cy.get("input#passwordConfirmation").type("password2");
+      cy.get("form").submit();
+
+      cy.get(".border-red-200").should("contain.text", "do not match");
+      cy.url().should("include", "/signup");
+    });
+
+    it("shows error for password too short", () => {
+      cy.visit("/signup");
+
+      cy.get("input#email").type("short@example.com");
+      cy.get("input#password").type("12345");
+      cy.get("input#passwordConfirmation").type("12345");
+      cy.get("form").submit();
+
+      cy.get(".border-red-200").should("contain.text", "at least 6 characters");
+    });
+  });
+
+  describe("Logout", () => {
+    it("logs out and redirects to home", () => {
+      cy.visit("/login");
+      cy.get("input#email").type("alice@example.com");
+      cy.get("input#password").type("iloveduck");
+      cy.get("form").submit();
+
+      cy.url({ timeout: 10000 }).should("not.include", "/login");
+      cy.contains("alice@example.com", { timeout: 10000 }).should("be.visible");
+
+      cy.contains("button", "Logout").click();
+
+      cy.url({ timeout: 10000 }).should("eq", Cypress.config().baseUrl + "/");
+      cy.contains("button", "Logout").should("not.exist");
+    });
+  });
+});

--- a/cypress/e2e/business/cart.cy.ts
+++ b/cypress/e2e/business/cart.cy.ts
@@ -1,0 +1,117 @@
+describe("Cart (E2E)", () => {
+  beforeEach(() => {
+    cy.loginAsAlice();
+  });
+
+  it("adds a product to cart from product detail page", () => {
+    cy.request("GET", "/api/products").then((response) => {
+      const product = response.body[0];
+
+      cy.visit(`/products/${product.id}`);
+      cy.contains("button", "Add to Cart").click();
+
+      cy.url({ timeout: 10000 }).should("include", "/cart");
+      cy.contains(product.name).should("be.visible");
+    });
+  });
+
+  it("displays cart items with quantities and totals", () => {
+    cy.request("GET", "/api/products").then((response) => {
+      const product = response.body[0];
+
+      cy.request({
+        method: "POST",
+        url: "/api/cart/add",
+        body: { productId: product.id, quantity: 2 },
+      });
+
+      cy.visit("/cart");
+
+      cy.contains(product.name).should("be.visible");
+      cy.contains("Order Summary").should("be.visible");
+      cy.contains("Proceed to Checkout").should("be.visible");
+    });
+  });
+
+  it("updates cart item quantity with +/- buttons", () => {
+    cy.request("GET", "/api/cart").then((cartResponse) => {
+      const items = cartResponse.body.cartItems || [];
+      items.forEach(
+        (item: { id: string }) =>
+          void cy.request({
+            method: "DELETE",
+            url: `/api/cart/items/${item.id}`,
+          })
+      );
+    });
+
+    cy.request("GET", "/api/products").then((response) => {
+      const product = response.body[0];
+
+      cy.request({
+        method: "POST",
+        url: "/api/cart/add",
+        body: { productId: product.id, quantity: 1 },
+      });
+
+      cy.visit("/cart");
+      cy.contains(product.name).should("be.visible");
+
+      cy.get('button[aria-label="Increase quantity"]').first().click();
+
+      cy.get('button[aria-label="Decrease quantity"]')
+        .first()
+        .parent()
+        .find("span")
+        .should("contain.text", "2");
+    });
+  });
+
+  it("removes item from cart", () => {
+    cy.request("GET", "/api/products").then((response) => {
+      const product = response.body[0];
+
+      cy.request({
+        method: "POST",
+        url: "/api/cart/add",
+        body: { productId: product.id, quantity: 1 },
+      });
+
+      cy.visit("/cart");
+      cy.contains(product.name).should("be.visible");
+
+      cy.contains("button", "Remove").click();
+
+      cy.contains("Your cart is empty", { timeout: 10000 }).should(
+        "be.visible"
+      );
+    });
+  });
+
+  it("shows empty cart message when no items", () => {
+    cy.request("GET", "/api/cart").then((response) => {
+      const items = response.body.cartItems || [];
+      items.forEach(
+        (item: { id: string }) =>
+          void cy.request({
+            method: "DELETE",
+            url: `/api/cart/items/${item.id}`,
+          })
+      );
+    });
+
+    cy.visit("/cart");
+
+    cy.contains("Your cart is empty").should("be.visible");
+    cy.contains("Continue Shopping").should("be.visible");
+  });
+
+  it("redirects to login when not authenticated", () => {
+    cy.clearCookies();
+    cy.window().then((win) => win.localStorage.clear());
+
+    cy.visit("/cart");
+
+    cy.url({ timeout: 10000 }).should("include", "/login");
+  });
+});

--- a/cypress/e2e/business/checkout.cy.ts
+++ b/cypress/e2e/business/checkout.cy.ts
@@ -1,0 +1,82 @@
+describe("Checkout (E2E)", () => {
+  it("completes the full purchase flow", () => {
+    cy.loginAsAlice();
+
+    cy.request("GET", "/api/products").then((response) => {
+      const product = response.body[0];
+
+      cy.request({
+        method: "POST",
+        url: "/api/cart/add",
+        body: { productId: product.id, quantity: 1 },
+      });
+
+      cy.visit("/checkout");
+
+      cy.contains("Checkout").should("be.visible");
+      cy.contains("Delivery Address").should("be.visible");
+      cy.contains("Order Items").should("be.visible");
+      cy.contains(product.name).should("be.visible");
+
+      cy.intercept("POST", "/api/orders").as("createOrder");
+      cy.contains("button", "Complete Payment").click();
+
+      cy.wait("@createOrder").then((interception) => {
+        expect(interception.response?.statusCode).to.eq(200);
+        expect(interception.response?.body).to.have.property("id");
+        expect(interception.response?.body.id).to.match(/^ORD-\d{3,}$/);
+        expect(interception.response?.body).to.have.property(
+          "status",
+          "PENDING"
+        );
+      });
+    });
+  });
+
+  it("shows order items and delivery address on checkout page", () => {
+    cy.loginAsAlice();
+
+    cy.request("GET", "/api/products").then((response) => {
+      const product = response.body[0];
+
+      cy.request({
+        method: "POST",
+        url: "/api/cart/add",
+        body: { productId: product.id, quantity: 3 },
+      });
+
+      cy.visit("/checkout");
+
+      cy.contains(product.name).should("be.visible");
+      cy.contains("Quantity:").should("be.visible");
+      cy.contains("Order Summary").should("be.visible");
+    });
+  });
+
+  it("navigates back to cart from checkout", () => {
+    cy.loginAsAlice();
+
+    cy.request("GET", "/api/products").then((response) => {
+      cy.request({
+        method: "POST",
+        url: "/api/cart/add",
+        body: { productId: response.body[0].id, quantity: 1 },
+      });
+
+      cy.visit("/checkout");
+
+      cy.contains("Back to Cart").click();
+
+      cy.url({ timeout: 10000 }).should("include", "/cart");
+    });
+  });
+
+  it("redirects to login when not authenticated", () => {
+    cy.clearCookies();
+    cy.window().then((win) => win.localStorage.clear());
+
+    cy.visit("/checkout");
+
+    cy.url({ timeout: 10000 }).should("include", "/login");
+  });
+});

--- a/cypress/e2e/business/products.cy.ts
+++ b/cypress/e2e/business/products.cy.ts
@@ -1,0 +1,45 @@
+describe("Products (E2E)", () => {
+  it("displays products on the home page", () => {
+    cy.visit("/");
+
+    cy.contains("Featured Products").should("be.visible");
+    cy.get("a[href^='/products/']").should("have.length.greaterThan", 0);
+  });
+
+  it("navigates to product detail page", () => {
+    cy.visit("/");
+
+    cy.get("a[href^='/products/']").first().click();
+
+    cy.url({ timeout: 10000 }).should("match", /\/products\/.+/);
+    cy.get("h1").should("not.be.empty");
+    cy.contains("Add to Cart").should("be.visible");
+    cy.contains("In Stock").should("be.visible");
+  });
+
+  it("displays product price and description", () => {
+    cy.request("GET", "/api/products").then((response) => {
+      const product = response.body[0];
+
+      cy.visit(`/products/${product.id}`);
+
+      cy.get("h1").should("contain.text", product.name);
+      cy.contains(`$${product.price.toFixed(2)}`).should("be.visible");
+    });
+  });
+
+  it("shows quantity controls on product detail", () => {
+    cy.request("GET", "/api/products").then((response) => {
+      const productId = response.body[0].id;
+      cy.visit(`/products/${productId}`);
+
+      cy.get("input#qty").should("have.value", "1");
+
+      cy.get('button[aria-label="Increase quantity"]').click();
+      cy.get("input#qty").should("have.value", "2");
+
+      cy.get('button[aria-label="Decrease quantity"]').click();
+      cy.get("input#qty").should("have.value", "1");
+    });
+  });
+});

--- a/cypress/e2e/business/profile.cy.ts
+++ b/cypress/e2e/business/profile.cy.ts
@@ -1,0 +1,57 @@
+describe("Profile (E2E)", () => {
+  beforeEach(() => {
+    cy.loginAsAlice();
+  });
+
+  it("displays user profile information", () => {
+    cy.visit("/profile");
+
+    cy.contains("alice@example.com").should("be.visible");
+    cy.contains("CUSTOMER").should("be.visible");
+    cy.get("input#displayName").should("be.visible");
+    cy.get("textarea#bio").should("be.visible");
+  });
+
+  it("updates display name", () => {
+    const displayName = `Alice E2E ${Date.now()}`;
+
+    cy.visit("/profile");
+
+    cy.get("input#displayName").clear().type(displayName);
+
+    cy.intercept("POST", "/api/user/profile").as("updateProfile");
+    cy.contains("button", "Save Profile").click();
+    cy.wait("@updateProfile").then((interception) => {
+      expect(interception.response?.statusCode).to.eq(200);
+    });
+
+    cy.reload();
+    cy.get("input#displayName").should("have.value", displayName);
+  });
+
+  it("updates bio", () => {
+    const bio = `E2E test bio ${Date.now()}`;
+
+    cy.visit("/profile");
+
+    cy.get("textarea#bio").clear().type(bio);
+
+    cy.intercept("POST", "/api/user/profile").as("updateProfile");
+    cy.contains("button", "Save Profile").click();
+    cy.wait("@updateProfile").then((interception) => {
+      expect(interception.response?.statusCode).to.eq(200);
+    });
+
+    cy.reload();
+    cy.get("textarea#bio").should("have.value", bio);
+  });
+
+  it("redirects to login when not authenticated", () => {
+    cy.clearCookies();
+    cy.window().then((win) => win.localStorage.clear());
+
+    cy.visit("/profile");
+
+    cy.url({ timeout: 10000 }).should("include", "/login");
+  });
+});

--- a/cypress/e2e/business/reviews.cy.ts
+++ b/cypress/e2e/business/reviews.cy.ts
@@ -1,0 +1,66 @@
+describe("Reviews (E2E)", () => {
+  it("submits a review on a product page", () => {
+    cy.loginAsAlice();
+
+    cy.request("GET", "/api/products").then((response) => {
+      const productId = response.body[0].id;
+
+      cy.visit(`/products/${productId}`);
+
+      cy.contains("Reviews").should("be.visible");
+
+      const reviewText = `Great product! Review ${Date.now()}`;
+      cy.get("textarea#review").type(reviewText);
+
+      cy.intercept("POST", `/api/products/${productId}/reviews`).as(
+        "submitReview"
+      );
+      cy.contains("button", "Submit Review").click();
+
+      cy.wait("@submitReview").then((interception) => {
+        expect(interception.response?.statusCode).to.eq(201);
+      });
+
+      cy.contains(reviewText, { timeout: 10000 }).should("exist");
+    });
+  });
+
+  it("pre-fills author with user email when logged in", () => {
+    cy.loginAsAlice();
+
+    cy.request("GET", "/api/products").then((response) => {
+      const productId = response.body[0].id;
+      cy.visit(`/products/${productId}`);
+
+      cy.get("input#reviewAuthor").should("have.value", "alice@example.com");
+    });
+  });
+
+  it("disables submit button when review content is empty", () => {
+    cy.request("GET", "/api/products").then((response) => {
+      const productId = response.body[0].id;
+      cy.visit(`/products/${productId}`);
+
+      cy.contains("button", "Submit Review").should("be.disabled");
+    });
+  });
+
+  it("clears review form after successful submission", () => {
+    cy.loginAsAlice();
+
+    cy.request("GET", "/api/products").then((response) => {
+      const productId = response.body[0].id;
+
+      cy.visit(`/products/${productId}`);
+      cy.get("textarea#review").type("Clearing test review");
+
+      cy.intercept("POST", `/api/products/${productId}/reviews`).as(
+        "submitReview"
+      );
+      cy.contains("button", "Submit Review").click();
+      cy.wait("@submitReview");
+
+      cy.get("textarea#review").should("have.value", "");
+    });
+  });
+});

--- a/tests/api/business/auth.test.ts
+++ b/tests/api/business/auth.test.ts
@@ -1,0 +1,143 @@
+import {
+  apiRequest,
+  extractAuthTokenFromHeaders,
+  TEST_USERS,
+} from "../../helpers/api";
+
+describe("Authentication (Business Logic)", () => {
+  const uniqueEmail = `test-${Date.now()}@example.com`;
+  const password = "testpassword123";
+
+  describe("POST /api/auth/signup", () => {
+    it("creates a new account and returns user data with auth cookie", async () => {
+      const { status, data, headers } = await apiRequest<{
+        user: { id: string; email: string; role: string };
+      }>("/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({ email: uniqueEmail, password }),
+      });
+
+      expect(status).toBe(200);
+      expect(data.user).toMatchObject({
+        email: uniqueEmail,
+        role: "CUSTOMER",
+      });
+      expect(data.user.id).toBeDefined();
+
+      const token = extractAuthTokenFromHeaders(headers);
+      expect(token).not.toBeNull();
+    });
+
+    it("rejects duplicate email registration", async () => {
+      const { status, data } = await apiRequest<{ error: string }>(
+        "/api/auth/signup",
+        {
+          method: "POST",
+          body: JSON.stringify({ email: uniqueEmail, password }),
+        }
+      );
+
+      expect(status).toBe(409);
+      expect(data.error).toMatch(/already registered/i);
+    });
+
+    it("rejects signup without email or password", async () => {
+      const { status: s1 } = await apiRequest("/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({ email: "no-pass@example.com" }),
+      });
+      expect(s1).toBe(400);
+
+      const { status: s2 } = await apiRequest("/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify({ password: "nopass" }),
+      });
+      expect(s2).toBe(400);
+    });
+  });
+
+  describe("POST /api/auth/login", () => {
+    it("logs in with valid credentials and returns auth cookie", async () => {
+      const { status, data, headers } = await apiRequest<{
+        user: { id: string; email: string; role: string };
+      }>("/api/auth/login", {
+        method: "POST",
+        body: JSON.stringify({
+          email: TEST_USERS.alice.email,
+          password: TEST_USERS.alice.password,
+        }),
+      });
+
+      expect(status).toBe(200);
+      expect(data.user.email).toBe(TEST_USERS.alice.email);
+      expect(data.user.role).toBe("CUSTOMER");
+
+      const token = extractAuthTokenFromHeaders(headers);
+      expect(token).not.toBeNull();
+    });
+
+    it("rejects invalid password", async () => {
+      const { status, data } = await apiRequest<{ error: string }>(
+        "/api/auth/login",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            email: TEST_USERS.alice.email,
+            password: "wrongpassword",
+          }),
+        }
+      );
+
+      expect(status).toBe(401);
+      expect(data.error).toBeDefined();
+    });
+
+    it("rejects non-existent email", async () => {
+      const { status } = await apiRequest("/api/auth/login", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "nonexistent@example.com",
+          password: "whatever",
+        }),
+      });
+
+      expect(status).toBe(401);
+    });
+
+    it("rejects login without credentials", async () => {
+      const { status } = await apiRequest("/api/auth/login", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      expect(status).toBe(400);
+    });
+
+    it("admin login returns admin role", async () => {
+      const { status, data } = await apiRequest<{
+        user: { role: string };
+      }>("/api/auth/login", {
+        method: "POST",
+        body: JSON.stringify({
+          email: TEST_USERS.admin.email,
+          password: TEST_USERS.admin.password,
+        }),
+      });
+
+      expect(status).toBe(200);
+      expect(data.user.role).toBe("ADMIN");
+    });
+  });
+
+  describe("POST /api/auth/logout", () => {
+    it("clears the auth cookie on logout", async () => {
+      const { status, data } = await apiRequest<{ success: boolean }>(
+        "/api/auth/logout",
+        { method: "POST" }
+      );
+
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+  });
+});

--- a/tests/api/business/cart.test.ts
+++ b/tests/api/business/cart.test.ts
@@ -1,0 +1,251 @@
+import {
+  apiRequest,
+  loginOrFail,
+  authHeaders,
+  TEST_USERS,
+  getFirstProductId,
+} from "../../helpers/api";
+
+interface CartResponse {
+  cartItems: {
+    id: string;
+    productId: string;
+    quantity: number;
+    product: { id: string; name: string; price: number };
+  }[];
+  total: number;
+}
+
+describe("Cart (Business Logic)", () => {
+  let aliceToken: string;
+  let productId: string;
+
+  beforeAll(async () => {
+    aliceToken = await loginOrFail(
+      TEST_USERS.alice.email,
+      TEST_USERS.alice.password
+    );
+    productId = await getFirstProductId();
+  });
+
+  describe("POST /api/cart/add", () => {
+    it("adds a product to the cart", async () => {
+      const { status, data } = await apiRequest<{ success: boolean }>(
+        "/api/cart/add",
+        {
+          method: "POST",
+          headers: authHeaders(aliceToken),
+          body: JSON.stringify({ productId, quantity: 1 }),
+        }
+      );
+
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+
+    it("increments quantity when adding the same product again", async () => {
+      const { data: cartBefore } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      const itemBefore = cartBefore.cartItems.find(
+        (i) => i.productId === productId
+      );
+      const qtyBefore = itemBefore?.quantity ?? 0;
+
+      await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ productId, quantity: 2 }),
+      });
+
+      const { data: cartAfter } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      const itemAfter = cartAfter.cartItems.find(
+        (i) => i.productId === productId
+      );
+
+      expect(itemAfter).toBeDefined();
+      expect(itemAfter!.quantity).toBe(qtyBefore + 2);
+    });
+
+    it("rejects adding without productId or quantity", async () => {
+      const { status: s1 } = await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ quantity: 1 }),
+      });
+      expect(s1).toBe(400);
+
+      const { status: s2 } = await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ productId }),
+      });
+      expect(s2).toBe(400);
+    });
+
+    it("rejects adding with invalid quantity", async () => {
+      const { status } = await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ productId, quantity: 0 }),
+      });
+
+      expect(status).toBe(400);
+    });
+
+    it("rejects adding a non-existent product", async () => {
+      const { status } = await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ productId: "fake-product-id", quantity: 1 }),
+      });
+
+      expect(status).toBe(404);
+    });
+
+    it("requires authentication", async () => {
+      const { status } = await apiRequest("/api/cart/add", {
+        method: "POST",
+        body: JSON.stringify({ productId, quantity: 1 }),
+      });
+
+      expect(status).toBe(401);
+    });
+  });
+
+  describe("GET /api/cart", () => {
+    it("returns the user cart with items and total", async () => {
+      const { status, data } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+
+      expect(status).toBe(200);
+      expect(Array.isArray(data.cartItems)).toBe(true);
+      expect(typeof data.total).toBe("number");
+
+      if (data.cartItems.length > 0) {
+        const item = data.cartItems[0];
+        expect(item).toHaveProperty("id");
+        expect(item).toHaveProperty("productId");
+        expect(item).toHaveProperty("quantity");
+        expect(item.product).toHaveProperty("name");
+        expect(item.product).toHaveProperty("price");
+      }
+    });
+
+    it("returns empty cart for user with no items", async () => {
+      const bobToken = await loginOrFail(
+        TEST_USERS.bob.email,
+        TEST_USERS.bob.password
+      );
+
+      const { status, data } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(bobToken),
+      });
+
+      expect(status).toBe(200);
+      expect(data.total).toBe(0);
+      expect(data.cartItems).toHaveLength(0);
+    });
+
+    it("requires authentication", async () => {
+      const { status } = await apiRequest("/api/cart");
+      expect(status).toBe(401);
+    });
+  });
+
+  describe("PATCH /api/cart/items/:id", () => {
+    it("updates cart item quantity", async () => {
+      const { data: cart } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      const cartItem = cart.cartItems[0];
+      if (!cartItem) return;
+
+      const { status, data } = await apiRequest<{
+        success: boolean;
+        cartItem: { quantity: number };
+      }>(`/api/cart/items/${cartItem.id}`, {
+        method: "PATCH",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ quantity: 5 }),
+      });
+
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.cartItem.quantity).toBe(5);
+    });
+
+    it("rejects invalid quantity", async () => {
+      const { data: cart } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      const cartItem = cart.cartItems[0];
+      if (!cartItem) return;
+
+      const { status } = await apiRequest(`/api/cart/items/${cartItem.id}`, {
+        method: "PATCH",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ quantity: 0 }),
+      });
+
+      expect(status).toBe(400);
+    });
+
+    it("returns 404 for non-existent cart item", async () => {
+      const { status } = await apiRequest("/api/cart/items/non-existent-id", {
+        method: "PATCH",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ quantity: 1 }),
+      });
+
+      expect(status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/cart/items/:id", () => {
+    it("removes item from cart", async () => {
+      await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ productId, quantity: 1 }),
+      });
+
+      const { data: cart } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      const cartItem = cart.cartItems.find((i) => i.productId === productId);
+      expect(cartItem).toBeDefined();
+
+      const { status, data } = await apiRequest<{ success: boolean }>(
+        `/api/cart/items/${cartItem!.id}`,
+        {
+          method: "DELETE",
+          headers: authHeaders(aliceToken),
+        }
+      );
+
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+
+      const { data: cartAfter } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      const deletedItem = cartAfter.cartItems.find(
+        (i) => i.id === cartItem!.id
+      );
+      expect(deletedItem).toBeUndefined();
+    });
+
+    it("returns 404 for non-existent cart item", async () => {
+      const { status } = await apiRequest("/api/cart/items/non-existent-id", {
+        method: "DELETE",
+        headers: authHeaders(aliceToken),
+      });
+
+      expect(status).toBe(404);
+    });
+  });
+});

--- a/tests/api/business/orders.test.ts
+++ b/tests/api/business/orders.test.ts
@@ -1,0 +1,230 @@
+import {
+  apiRequest,
+  loginOrFail,
+  authHeaders,
+  TEST_USERS,
+  getFirstProductId,
+} from "../../helpers/api";
+
+interface CartResponse {
+  cartItems: { id: string; productId: string; quantity: number }[];
+  total: number;
+}
+
+interface OrderResponse {
+  id: string;
+  total: number;
+  status: string;
+  flag?: string;
+}
+
+interface OrderDetailResponse {
+  id: string;
+  total: number;
+  status: string;
+  customerName: string;
+  customerEmail: string;
+  deliveryAddress: {
+    street: string;
+    city: string;
+    state: string;
+    zipCode: string;
+    country: string;
+  };
+}
+
+describe("Orders (Business Logic)", () => {
+  let aliceToken: string;
+  let productId: string;
+
+  beforeAll(async () => {
+    aliceToken = await loginOrFail(
+      TEST_USERS.alice.email,
+      TEST_USERS.alice.password
+    );
+    productId = await getFirstProductId();
+  });
+
+  describe("POST /api/orders", () => {
+    it("creates an order from the cart with correct total", async () => {
+      await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ productId, quantity: 1 }),
+      });
+
+      const { data: cart } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      expect(cart.cartItems.length).toBeGreaterThan(0);
+
+      const { status, data } = await apiRequest<OrderResponse>("/api/orders", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ total: cart.total }),
+      });
+
+      expect(status).toBe(200);
+      expect(data.id).toMatch(/^ORD-\d{3,}$/);
+      expect(data.total).toBe(cart.total);
+      expect(data.status).toBe("PENDING");
+      expect(data.flag).toBeUndefined();
+    });
+
+    it("clears the cart after placing an order", async () => {
+      await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ productId, quantity: 1 }),
+      });
+
+      const { data: cartBefore } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      expect(cartBefore.cartItems.length).toBeGreaterThan(0);
+
+      await apiRequest("/api/orders", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ total: cartBefore.total }),
+      });
+
+      const { data: cartAfter } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+      expect(cartAfter.cartItems).toHaveLength(0);
+      expect(cartAfter.total).toBe(0);
+    });
+
+    it("rejects order with empty cart", async () => {
+      const { data: cart } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+
+      if (cart.cartItems.length > 0) {
+        for (const item of cart.cartItems) {
+          await apiRequest(`/api/cart/items/${item.id}`, {
+            method: "DELETE",
+            headers: authHeaders(aliceToken),
+          });
+        }
+      }
+
+      const { status, data } = await apiRequest<{ error: string }>(
+        "/api/orders",
+        {
+          method: "POST",
+          headers: authHeaders(aliceToken),
+          body: JSON.stringify({ total: 10 }),
+        }
+      );
+
+      expect(status).toBe(400);
+      expect(data.error).toMatch(/cart is empty/i);
+    });
+
+    it("rejects order with invalid total", async () => {
+      const { status: s1 } = await apiRequest("/api/orders", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ total: 0 }),
+      });
+      expect(s1).toBe(400);
+
+      const { status: s2 } = await apiRequest("/api/orders", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ total: -5 }),
+      });
+      expect(s2).toBe(400);
+    });
+
+    it("requires authentication", async () => {
+      const { status } = await apiRequest("/api/orders", {
+        method: "POST",
+        body: JSON.stringify({ total: 10 }),
+      });
+
+      expect(status).toBe(401);
+    });
+  });
+
+  describe("GET /api/orders/:id", () => {
+    let orderId: string;
+
+    beforeAll(async () => {
+      await apiRequest("/api/cart/add", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ productId, quantity: 1 }),
+      });
+
+      const { data: cart } = await apiRequest<CartResponse>("/api/cart", {
+        headers: authHeaders(aliceToken),
+      });
+
+      const { data } = await apiRequest<OrderResponse>("/api/orders", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ total: cart.total }),
+      });
+
+      orderId = data.id;
+    });
+
+    it("returns order details for the owner", async () => {
+      const { status, data } = await apiRequest<OrderDetailResponse>(
+        `/api/orders/${orderId}`,
+        { headers: authHeaders(aliceToken) }
+      );
+
+      expect(status).toBe(200);
+      expect(data.id).toBe(orderId);
+      expect(data.status).toBe("PENDING");
+      expect(data.customerEmail).toBe(TEST_USERS.alice.email);
+      expect(data.deliveryAddress).toBeDefined();
+      expect(data.deliveryAddress.street).toBeDefined();
+      expect(data.deliveryAddress.city).toBeDefined();
+    });
+
+    it("returns 404 for non-existent order", async () => {
+      const { status } = await apiRequest("/api/orders/ORD-999999", {
+        headers: authHeaders(aliceToken),
+      });
+
+      expect(status).toBe(404);
+    });
+
+    it("requires authentication", async () => {
+      const { status } = await apiRequest(`/api/orders/${orderId}`);
+      expect(status).toBe(401);
+    });
+  });
+
+  describe("GET /api/orders (admin)", () => {
+    it("admin can list all orders", async () => {
+      const adminToken = await loginOrFail(
+        TEST_USERS.admin.email,
+        TEST_USERS.admin.password
+      );
+
+      const { status, data } = await apiRequest<
+        { id: string; total: number; status: string }[]
+      >("/api/orders", {
+        headers: authHeaders(adminToken),
+      });
+
+      expect(status).toBe(200);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it("non-admin cannot list all orders", async () => {
+      const { status } = await apiRequest("/api/orders", {
+        headers: authHeaders(aliceToken),
+      });
+
+      expect(status).toBe(403);
+    });
+  });
+});

--- a/tests/api/business/products.test.ts
+++ b/tests/api/business/products.test.ts
@@ -1,0 +1,51 @@
+import { apiRequest, getFirstProductId } from "../../helpers/api";
+
+describe("Products (Business Logic)", () => {
+  describe("GET /api/products", () => {
+    it("returns a list of products", async () => {
+      const { status, data } =
+        await apiRequest<
+          { id: string; name: string; price: number; imageUrl: string }[]
+        >("/api/products");
+
+      expect(status).toBe(200);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+
+      const product = data[0];
+      expect(product).toHaveProperty("id");
+      expect(product).toHaveProperty("name");
+      expect(product).toHaveProperty("price");
+      expect(typeof product.price).toBe("number");
+      expect(product.price).toBeGreaterThan(0);
+    });
+  });
+
+  describe("GET /api/products/:id", () => {
+    it("returns a single product by ID", async () => {
+      const productId = await getFirstProductId();
+
+      const { status, data } = await apiRequest<{
+        id: string;
+        name: string;
+        price: number;
+        description: string | null;
+        imageUrl: string;
+      }>(`/api/products/${productId}`);
+
+      expect(status).toBe(200);
+      expect(data.id).toBe(productId);
+      expect(data.name).toBeDefined();
+      expect(typeof data.price).toBe("number");
+    });
+
+    it("returns 404 for non-existent product", async () => {
+      const { status, data } = await apiRequest<{ error: string }>(
+        "/api/products/non-existent-id"
+      );
+
+      expect(status).toBe(404);
+      expect(data.error).toMatch(/not found/i);
+    });
+  });
+});

--- a/tests/api/business/profile.test.ts
+++ b/tests/api/business/profile.test.ts
@@ -1,0 +1,132 @@
+import {
+  apiRequest,
+  loginOrFail,
+  authHeaders,
+  TEST_USERS,
+} from "../../helpers/api";
+
+interface ProfileResponse {
+  id: string;
+  email: string;
+  displayName: string | null;
+  bio: string | null;
+  role: string;
+}
+
+describe("User Profile (Business Logic)", () => {
+  let aliceToken: string;
+
+  beforeAll(async () => {
+    aliceToken = await loginOrFail(
+      TEST_USERS.alice.email,
+      TEST_USERS.alice.password
+    );
+  });
+
+  describe("GET /api/user/profile", () => {
+    it("returns the authenticated user profile", async () => {
+      const { status, data } = await apiRequest<ProfileResponse>(
+        "/api/user/profile",
+        { headers: authHeaders(aliceToken) }
+      );
+
+      expect(status).toBe(200);
+      expect(data.email).toBe(TEST_USERS.alice.email);
+      expect(data.role).toBe("CUSTOMER");
+      expect(data.id).toBeDefined();
+    });
+
+    it("requires authentication", async () => {
+      const { status } = await apiRequest("/api/user/profile");
+      expect(status).toBe(401);
+    });
+  });
+
+  describe("POST /api/user/profile", () => {
+    it("updates display name", async () => {
+      const displayName = `Alice_${Date.now()}`;
+
+      const { status, data } = await apiRequest<{
+        message: string;
+        user: ProfileResponse;
+      }>("/api/user/profile", {
+        method: "POST",
+        headers: {
+          ...authHeaders(aliceToken),
+          Referer: "http://localhost:3000/profile",
+        },
+        body: JSON.stringify({ displayName }),
+      });
+
+      expect(status).toBe(200);
+      expect(data.message).toMatch(/updated/i);
+      expect(data.user.displayName).toBe(displayName);
+    });
+
+    it("updates bio", async () => {
+      const bio = "I love security testing!";
+
+      const { status, data } = await apiRequest<{
+        user: ProfileResponse;
+      }>("/api/user/profile", {
+        method: "POST",
+        headers: {
+          ...authHeaders(aliceToken),
+          Referer: "http://localhost:3000/profile",
+        },
+        body: JSON.stringify({ bio }),
+      });
+
+      expect(status).toBe(200);
+      expect(data.user.bio).toBe(bio);
+    });
+
+    it("updates both display name and bio at once", async () => {
+      const displayName = `Alice_Both_${Date.now()}`;
+      const bio = "Updated bio";
+
+      const { status, data } = await apiRequest<{
+        user: ProfileResponse;
+      }>("/api/user/profile", {
+        method: "POST",
+        headers: {
+          ...authHeaders(aliceToken),
+          Referer: "http://localhost:3000/profile",
+        },
+        body: JSON.stringify({ displayName, bio }),
+      });
+
+      expect(status).toBe(200);
+      expect(data.user.displayName).toBe(displayName);
+      expect(data.user.bio).toBe(bio);
+    });
+
+    it("persists profile changes across requests", async () => {
+      const displayName = `Persistent_${Date.now()}`;
+
+      await apiRequest("/api/user/profile", {
+        method: "POST",
+        headers: {
+          ...authHeaders(aliceToken),
+          Referer: "http://localhost:3000/profile",
+        },
+        body: JSON.stringify({ displayName }),
+      });
+
+      const { data } = await apiRequest<ProfileResponse>("/api/user/profile", {
+        headers: authHeaders(aliceToken),
+      });
+
+      expect(data.displayName).toBe(displayName);
+    });
+
+    it("requires authentication", async () => {
+      const { status } = await apiRequest("/api/user/profile", {
+        method: "POST",
+        body: JSON.stringify({ displayName: "Hacker" }),
+      });
+
+      expect(status).toBe(401);
+    });
+  });
+});

--- a/tests/api/business/reviews.test.ts
+++ b/tests/api/business/reviews.test.ts
@@ -1,0 +1,154 @@
+import {
+  apiRequest,
+  loginOrFail,
+  authHeaders,
+  TEST_USERS,
+  getFirstProductId,
+} from "../../helpers/api";
+
+interface ReviewResponse {
+  id: string;
+  productId: string;
+  content: string;
+  author: string;
+  createdAt: string;
+}
+
+describe("Reviews (Business Logic)", () => {
+  let aliceToken: string;
+  let productId: string;
+
+  beforeAll(async () => {
+    aliceToken = await loginOrFail(
+      TEST_USERS.alice.email,
+      TEST_USERS.alice.password
+    );
+    productId = await getFirstProductId();
+  });
+
+  describe("POST /api/products/:id/reviews", () => {
+    it("creates a review as an authenticated user", async () => {
+      const { status, data } = await apiRequest<ReviewResponse>(
+        `/api/products/${productId}/reviews`,
+        {
+          method: "POST",
+          headers: authHeaders(aliceToken),
+          body: JSON.stringify({ content: "Great product, highly recommend!" }),
+        }
+      );
+
+      expect(status).toBe(201);
+      expect(data.content).toBe("Great product, highly recommend!");
+      expect(data.author).toBe(TEST_USERS.alice.email);
+      expect(data.productId).toBe(productId);
+      expect(data.id).toBeDefined();
+      expect(data.createdAt).toBeDefined();
+    });
+
+    it("creates a review as anonymous (no auth)", async () => {
+      const { status, data } = await apiRequest<ReviewResponse>(
+        `/api/products/${productId}/reviews`,
+        {
+          method: "POST",
+          body: JSON.stringify({ content: "Nice product!" }),
+        }
+      );
+
+      expect(status).toBe(201);
+      expect(data.author).toBe("anonymous");
+      expect(data.content).toBe("Nice product!");
+    });
+
+    it("trims whitespace from content", async () => {
+      const { status, data } = await apiRequest<ReviewResponse>(
+        `/api/products/${productId}/reviews`,
+        {
+          method: "POST",
+          body: JSON.stringify({ content: "  Trimmed review  " }),
+        }
+      );
+
+      expect(status).toBe(201);
+      expect(data.content).toBe("Trimmed review");
+    });
+
+    it("rejects empty content", async () => {
+      const { status: s1 } = await apiRequest(
+        `/api/products/${productId}/reviews`,
+        {
+          method: "POST",
+          body: JSON.stringify({ content: "" }),
+        }
+      );
+      expect(s1).toBe(400);
+
+      const { status: s2 } = await apiRequest(
+        `/api/products/${productId}/reviews`,
+        {
+          method: "POST",
+          body: JSON.stringify({ content: "   " }),
+        }
+      );
+      expect(s2).toBe(400);
+
+      const { status: s3 } = await apiRequest(
+        `/api/products/${productId}/reviews`,
+        {
+          method: "POST",
+          body: JSON.stringify({}),
+        }
+      );
+      expect(s3).toBe(400);
+    });
+
+    it("rejects review for non-existent product", async () => {
+      const { status } = await apiRequest(
+        "/api/products/non-existent-id/reviews",
+        {
+          method: "POST",
+          body: JSON.stringify({ content: "A review" }),
+        }
+      );
+
+      expect(status).toBe(404);
+    });
+  });
+
+  describe("GET /api/products/:id/reviews", () => {
+    it("returns reviews for a product", async () => {
+      const { status, data } = await apiRequest<ReviewResponse[]>(
+        `/api/products/${productId}/reviews`
+      );
+
+      expect(status).toBe(200);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+
+      const review = data[0];
+      expect(review).toHaveProperty("id");
+      expect(review).toHaveProperty("content");
+      expect(review).toHaveProperty("author");
+      expect(review).toHaveProperty("createdAt");
+    });
+
+    it("returns reviews sorted by most recent first", async () => {
+      const { data } = await apiRequest<ReviewResponse[]>(
+        `/api/products/${productId}/reviews`
+      );
+
+      if (data.length >= 2) {
+        const first = new Date(data[0].createdAt).getTime();
+        const second = new Date(data[1].createdAt).getTime();
+        expect(first).toBeGreaterThanOrEqual(second);
+      }
+    });
+
+    it("returns 404 for non-existent product", async () => {
+      const { status } = await apiRequest(
+        "/api/products/non-existent-id/reviews"
+      );
+
+      expect(status).toBe(404);
+    });
+  });
+});

--- a/tests/api/business/wishlists.test.ts
+++ b/tests/api/business/wishlists.test.ts
@@ -1,0 +1,179 @@
+import {
+  apiRequest,
+  loginOrFail,
+  authHeaders,
+  TEST_USERS,
+} from "../../helpers/api";
+
+interface WishlistResponse {
+  id: string;
+  name: string;
+  isPublic: boolean;
+  createdAt: string;
+  updatedAt: string;
+  items: {
+    id: string;
+    addedAt: string;
+    product: { id: string; name: string; price: number };
+  }[];
+}
+
+describe("Wishlists (Business Logic)", () => {
+  let aliceToken: string;
+
+  beforeAll(async () => {
+    aliceToken = await loginOrFail(
+      TEST_USERS.alice.email,
+      TEST_USERS.alice.password
+    );
+  });
+
+  describe("POST /api/wishlists", () => {
+    it("creates a new wishlist", async () => {
+      const name = `Test Wishlist ${Date.now()}`;
+
+      const { status, data } = await apiRequest<WishlistResponse>(
+        "/api/wishlists",
+        {
+          method: "POST",
+          headers: authHeaders(aliceToken),
+          body: JSON.stringify({ name }),
+        }
+      );
+
+      expect(status).toBe(201);
+      expect(data.name).toBe(name);
+      expect(data.id).toBeDefined();
+      expect(data.isPublic).toBe(false);
+      expect(data.items).toHaveLength(0);
+    });
+
+    it("trims whitespace from name", async () => {
+      const { status, data } = await apiRequest<WishlistResponse>(
+        "/api/wishlists",
+        {
+          method: "POST",
+          headers: authHeaders(aliceToken),
+          body: JSON.stringify({ name: "  Trimmed Name  " }),
+        }
+      );
+
+      expect(status).toBe(201);
+      expect(data.name).toBe("Trimmed Name");
+    });
+
+    it("rejects empty name", async () => {
+      const { status: s1 } = await apiRequest("/api/wishlists", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ name: "" }),
+      });
+      expect(s1).toBe(400);
+
+      const { status: s2 } = await apiRequest("/api/wishlists", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({ name: "   " }),
+      });
+      expect(s2).toBe(400);
+
+      const { status: s3 } = await apiRequest("/api/wishlists", {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({}),
+      });
+      expect(s3).toBe(400);
+    });
+
+    it("requires authentication", async () => {
+      const { status } = await apiRequest("/api/wishlists", {
+        method: "POST",
+        body: JSON.stringify({ name: "Unauthorized Wishlist" }),
+      });
+
+      expect(status).toBe(401);
+    });
+  });
+
+  describe("GET /api/wishlists", () => {
+    it("returns user wishlists", async () => {
+      const { status, data } = await apiRequest<WishlistResponse[]>(
+        "/api/wishlists",
+        {
+          headers: authHeaders(aliceToken),
+        }
+      );
+
+      expect(status).toBe(200);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+
+      const wishlist = data[0];
+      expect(wishlist).toHaveProperty("id");
+      expect(wishlist).toHaveProperty("name");
+      expect(wishlist).toHaveProperty("isPublic");
+      expect(wishlist).toHaveProperty("items");
+    });
+
+    it("requires authentication", async () => {
+      const { status } = await apiRequest("/api/wishlists");
+      expect(status).toBe(401);
+    });
+  });
+
+  describe("DELETE /api/wishlists/:id", () => {
+    it("deletes own wishlist", async () => {
+      const { data: created } = await apiRequest<WishlistResponse>(
+        "/api/wishlists",
+        {
+          method: "POST",
+          headers: authHeaders(aliceToken),
+          body: JSON.stringify({ name: `To Delete ${Date.now()}` }),
+        }
+      );
+
+      const { status, data } = await apiRequest<{ success: boolean }>(
+        `/api/wishlists/${created.id}`,
+        {
+          method: "DELETE",
+          headers: authHeaders(aliceToken),
+        }
+      );
+
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+
+    it("returns 404 for non-existent wishlist", async () => {
+      const { status } = await apiRequest("/api/wishlists/non-existent-id", {
+        method: "DELETE",
+        headers: authHeaders(aliceToken),
+      });
+
+      expect(status).toBe(404);
+    });
+
+    it("prevents deleting another user's wishlist", async () => {
+      const { data: created } = await apiRequest<WishlistResponse>(
+        "/api/wishlists",
+        {
+          method: "POST",
+          headers: authHeaders(aliceToken),
+          body: JSON.stringify({ name: `Alice Only ${Date.now()}` }),
+        }
+      );
+
+      const bobToken = await loginOrFail(
+        TEST_USERS.bob.email,
+        TEST_USERS.bob.password
+      );
+
+      const { status } = await apiRequest(`/api/wishlists/${created.id}`, {
+        method: "DELETE",
+        headers: authHeaders(bobToken),
+      });
+
+      expect(status).toBe(403);
+    });
+  });
+});

--- a/tests/unit/database-url.test.ts
+++ b/tests/unit/database-url.test.ts
@@ -1,0 +1,57 @@
+import path from "path";
+
+describe("getDatabaseUrl", () => {
+  const originalEnv = process.env.DATABASE_URL;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.DATABASE_URL = originalEnv;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+    jest.resetModules();
+  });
+
+  async function loadGetDatabaseUrl() {
+    const mod = await import("../../lib/database");
+    return mod.getDatabaseUrl;
+  }
+
+  it("returns default path when DATABASE_URL is not set", async () => {
+    delete process.env.DATABASE_URL;
+    const getDatabaseUrl = await loadGetDatabaseUrl();
+
+    const result = getDatabaseUrl();
+    const expectedPath = path.resolve(process.cwd(), "prisma", "dev.db");
+
+    expect(result).toBe(`file:${expectedPath}`);
+  });
+
+  it("resolves relative file:./  paths to absolute", async () => {
+    process.env.DATABASE_URL = "file:./prisma/test.db";
+    const getDatabaseUrl = await loadGetDatabaseUrl();
+
+    const result = getDatabaseUrl();
+    const expectedPath = path.resolve(process.cwd(), "prisma/test.db");
+
+    expect(result).toBe(`file:${expectedPath}`);
+  });
+
+  it("keeps absolute file: paths unchanged", async () => {
+    process.env.DATABASE_URL = "file:/absolute/path/to/db.sqlite";
+    const getDatabaseUrl = await loadGetDatabaseUrl();
+
+    const result = getDatabaseUrl();
+
+    expect(result).toBe("file:/absolute/path/to/db.sqlite");
+  });
+
+  it("strips surrounding quotes from DATABASE_URL", async () => {
+    process.env.DATABASE_URL = '"file:/some/path/db.sqlite"';
+    const getDatabaseUrl = await loadGetDatabaseUrl();
+
+    const result = getDatabaseUrl();
+
+    expect(result).toBe("file:/some/path/db.sqlite");
+  });
+});

--- a/tests/unit/jwt.test.ts
+++ b/tests/unit/jwt.test.ts
@@ -1,0 +1,89 @@
+import { createWeakJWT, decodeWeakJWT } from "../../lib/server-auth";
+
+describe("JWT (createWeakJWT / decodeWeakJWT)", () => {
+  const validPayload = {
+    id: "user-1",
+    email: "test@example.com",
+    role: "CUSTOMER",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  };
+
+  it("creates a valid JWT with 3 dot-separated parts", () => {
+    const token = createWeakJWT(validPayload);
+    const parts = token.split(".");
+
+    expect(parts).toHaveLength(3);
+    parts.forEach((part) => expect(part.length).toBeGreaterThan(0));
+  });
+
+  it("encodes header as HS256 JWT", () => {
+    const token = createWeakJWT(validPayload);
+    const header = JSON.parse(
+      Buffer.from(token.split(".")[0], "base64url").toString()
+    );
+
+    expect(header).toEqual({ alg: "HS256", typ: "JWT" });
+  });
+
+  it("roundtrips: decode(create(payload)) returns the original payload", () => {
+    const token = createWeakJWT(validPayload);
+    const decoded = decodeWeakJWT(token);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded!.id).toBe(validPayload.id);
+    expect(decoded!.email).toBe(validPayload.email);
+    expect(decoded!.role).toBe(validPayload.role);
+    expect(decoded!.exp).toBe(validPayload.exp);
+  });
+
+  it("returns null for expired token", () => {
+    const expiredPayload = {
+      ...validPayload,
+      exp: Math.floor(Date.now() / 1000) - 100,
+    };
+    const token = createWeakJWT(expiredPayload);
+
+    expect(decodeWeakJWT(token)).toBeNull();
+  });
+
+  it("returns null for tampered payload", () => {
+    const token = createWeakJWT(validPayload);
+    const [header, , signature] = token.split(".");
+
+    const tamperedBody = Buffer.from(
+      JSON.stringify({ ...validPayload, role: "ADMIN" })
+    ).toString("base64url");
+
+    expect(decodeWeakJWT(`${header}.${tamperedBody}.${signature}`)).toBeNull();
+  });
+
+  it("returns null for tampered signature", () => {
+    const token = createWeakJWT(validPayload);
+    const [header, body] = token.split(".");
+
+    expect(decodeWeakJWT(`${header}.${body}.invalidsignature`)).toBeNull();
+  });
+
+  it("returns null for malformed tokens", () => {
+    expect(decodeWeakJWT("")).toBeNull();
+    expect(decodeWeakJWT("onlyonepart")).toBeNull();
+    expect(decodeWeakJWT("two.parts")).toBeNull();
+    expect(decodeWeakJWT("a.b.c.d")).toBeNull();
+  });
+
+  it("returns null for invalid base64 body", () => {
+    const token = createWeakJWT(validPayload);
+    const [header, , signature] = token.split(".");
+
+    expect(decodeWeakJWT(`${header}.!!!invalid!!!.${signature}`)).toBeNull();
+  });
+
+  it("preserves optional supportAccess field", () => {
+    const payloadWithSupport = { ...validPayload, supportAccess: true };
+    const token = createWeakJWT(payloadWithSupport);
+    const decoded = decodeWeakJWT(token);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded!.supportAccess).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Add business logic test coverage across all three test layers (unit, API, E2E). Previously, tests only covered vulnerability exploitation and regression. Business flows like adding to cart, placing an order, leaving a review, signing up, updating a profile, and managing wishlists were untested.

Issue: https://github.com/kOaDT/oss-oopssec-store/issues/83

## Type of change

- [ ] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [ ] Documentation update
- [x] Other (please describe): Business logic test coverage

## Testing done

- **Unit tests (13 new):** `createWeakJWT`/`decodeWeakJWT` edge cases, `getDatabaseUrl` path resolution — all pass (`npx jest tests/unit/`)
- **API tests (60 new):** auth, products, cart, orders, reviews, profile, wishlists — all pass (`npx jest tests/api/business/`)
- **E2E tests (24 new):** full user flows through the UI (auth, products, cart, checkout, reviews, profile)
- All 229 existing tests still pass (no regressions)

## Checklist

- [x] Documentation updated (if applicable)

### If adding a new vulnerability

N/A — no new vulnerability added.