### PR TITLE
refactor: replace manual auth checks with withAuth/withAdminAuth wrap…

### DIFF
--- a/.cursor/rules/api-patterns.mdc
+++ b/.cursor/rules/api-patterns.mdc
@@ -9,26 +9,43 @@ globs:
 ## File Structure
 
 - Use Next.js App Router API route handlers (`route.ts`)
-- Export named functions: `GET`, `POST`, `PUT`, `DELETE`
+- Export named constants using `withAuth` or `withAdminAuth`: `export const GET = withAuth(...)`, `export const POST = withAdminAuth(...)`
 
 ## Imports
 
 ```typescript
 import { NextRequest, NextResponse } from "next/server";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth, withAdminAuth } from "@/lib/server-auth";
 import { prisma } from "@/lib/prisma";
 ```
 
 ## Authentication Pattern
 
+Use `withAuth` for routes requiring authentication. The user is passed as the third argument:
+
 ```typescript
-export async function GET(request: NextRequest) {
-  const user = await getAuthenticatedUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+export const GET = withAuth(async (request, _context, user) => {
+  // user is guaranteed to be authenticated
   // ... handler logic
-}
+});
+```
+
+For dynamic routes, use `context.params`:
+
+```typescript
+export const GET = withAuth(async (_request, context, user) => {
+  const { id } = await context.params;
+  // ... handler logic
+});
+```
+
+For admin-only routes, use `withAdminAuth`:
+
+```typescript
+export const GET = withAdminAuth(async (request, _context, user) => {
+  // user is guaranteed to be an authenticated admin
+  // ... handler logic
+});
 ```
 
 ## Response Pattern

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,70 +1,61 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAdminAuth } from "@/lib/server-auth";
 
-export async function GET(request: NextRequest) {
-  const user = await getAuthenticatedUser(request);
+export const GET = withAdminAuth(
+  async (request: NextRequest, _context, _user) => {
+    try {
+      const { searchParams } = new URL(request.url);
+      const filterIp = searchParams.get("ip");
 
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+      const totalVisits = await prisma.visitorLog.count();
+      const uniqueIps = await prisma.visitorLog.groupBy({
+        by: ["ip"],
+      });
 
-  if (user.role !== "ADMIN") {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+      let filteredVisits: unknown[] = [];
 
-  try {
-    const { searchParams } = new URL(request.url);
-    const filterIp = searchParams.get("ip");
-
-    const totalVisits = await prisma.visitorLog.count();
-    const uniqueIps = await prisma.visitorLog.groupBy({
-      by: ["ip"],
-    });
-
-    let filteredVisits: unknown[] = [];
-
-    if (filterIp) {
-      // Safe query using Prisma's parameterized queries
-      filteredVisits = await prisma.visitorLog.findMany({
-        where: {
-          ip: {
-            contains: filterIp,
+      if (filterIp) {
+        filteredVisits = await prisma.visitorLog.findMany({
+          where: {
+            ip: {
+              contains: filterIp,
+            },
           },
+          orderBy: { createdAt: "desc" },
+          take: 100,
+        });
+      } else {
+        filteredVisits = await prisma.visitorLog.findMany({
+          orderBy: { createdAt: "desc" },
+          take: 100,
+        });
+      }
+
+      const topIps = await prisma.visitorLog.groupBy({
+        by: ["ip"],
+        _count: { ip: true },
+        orderBy: { _count: { ip: "desc" } },
+        take: 10,
+      });
+
+      return NextResponse.json({
+        stats: {
+          totalVisits,
+          uniqueVisitors: uniqueIps.length,
         },
-        orderBy: { createdAt: "desc" },
-        take: 100,
+        topIps: topIps.map((item) => ({
+          ip: item.ip,
+          count: item._count.ip,
+        })),
+        visits: filteredVisits,
       });
-    } else {
-      filteredVisits = await prisma.visitorLog.findMany({
-        orderBy: { createdAt: "desc" },
-        take: 100,
-      });
+    } catch (error) {
+      console.error("Error fetching analytics:", error);
+      return NextResponse.json(
+        { error: "Failed to fetch analytics" },
+        { status: 500 }
+      );
     }
-
-    const topIps = await prisma.visitorLog.groupBy({
-      by: ["ip"],
-      _count: { ip: true },
-      orderBy: { _count: { ip: "desc" } },
-      take: 10,
-    });
-
-    return NextResponse.json({
-      stats: {
-        totalVisits,
-        uniqueVisitors: uniqueIps.length,
-      },
-      topIps: topIps.map((item) => ({
-        ip: item.ip,
-        count: item._count.ip,
-      })),
-      visits: filteredVisits,
-    });
-  } catch (error) {
-    console.error("Error fetching analytics:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch analytics" },
-      { status: 500 }
-    );
   }
-}
+);

--- a/app/api/admin/products/[id]/image/route.ts
+++ b/app/api/admin/products/[id]/image/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAdminAuth } from "@/lib/server-auth";
 import { writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
@@ -27,104 +27,97 @@ function containsMaliciousContent(content: string): boolean {
   );
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const user = await getAuthenticatedUser(request);
+export const POST = withAdminAuth(
+  async (request: NextRequest, context, _user) => {
+    try {
+      const { id } = await context.params;
 
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+      const product = await prisma.product.findUnique({
+        where: { id },
+      });
 
-    if (user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    const { id } = await params;
-
-    const product = await prisma.product.findUnique({
-      where: { id },
-    });
-
-    if (!product) {
-      return NextResponse.json({ error: "Product not found" }, { status: 404 });
-    }
-
-    const formData = await request.formData();
-    const file = formData.get("image") as File | null;
-
-    if (!file) {
-      return NextResponse.json(
-        { error: "No image file provided" },
-        { status: 400 }
-      );
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
-      return NextResponse.json(
-        { error: "File size exceeds 5MB limit" },
-        { status: 400 }
-      );
-    }
-
-    if (!ALLOWED_CONTENT_TYPES.includes(file.type)) {
-      return NextResponse.json(
-        {
-          error: "Invalid file type. Allowed types: JPEG, PNG, GIF, WebP, SVG",
-        },
-        { status: 400 }
-      );
-    }
-
-    const uploadsDir = join(process.cwd(), "uploads");
-    if (!existsSync(uploadsDir)) {
-      await mkdir(uploadsDir, { recursive: true });
-    }
-
-    const timestamp = Date.now();
-    const originalName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_");
-    const filename = `${id}-${timestamp}-${originalName}`;
-
-    const buffer = Buffer.from(await file.arrayBuffer());
-    const filepath = join(uploadsDir, filename);
-    await writeFile(filepath, buffer);
-
-    const imageUrl = `/api/uploads/${filename}`;
-
-    await prisma.product.update({
-      where: { id },
-      data: { imageUrl },
-    });
-
-    const isSvg = file.type === "image/svg+xml" || file.name.endsWith(".svg");
-    if (isSvg) {
-      const content = buffer.toString("utf-8");
-      if (containsMaliciousContent(content)) {
-        const flag = await prisma.flag.findUnique({
-          where: { slug: "malicious-file-upload" },
-        });
-
-        return NextResponse.json({
-          message: "Image uploaded successfully",
-          imageUrl,
-          productName: product.name,
-          flag: flag?.flag,
-        });
+      if (!product) {
+        return NextResponse.json(
+          { error: "Product not found" },
+          { status: 404 }
+        );
       }
-    }
 
-    return NextResponse.json({
-      message: "Image uploaded successfully",
-      imageUrl,
-      productName: product.name,
-    });
-  } catch (error) {
-    console.error("Error uploading image:", error);
-    return NextResponse.json(
-      { error: "Failed to upload image" },
-      { status: 500 }
-    );
+      const formData = await request.formData();
+      const file = formData.get("image") as File | null;
+
+      if (!file) {
+        return NextResponse.json(
+          { error: "No image file provided" },
+          { status: 400 }
+        );
+      }
+
+      if (file.size > MAX_FILE_SIZE) {
+        return NextResponse.json(
+          { error: "File size exceeds 5MB limit" },
+          { status: 400 }
+        );
+      }
+
+      if (!ALLOWED_CONTENT_TYPES.includes(file.type)) {
+        return NextResponse.json(
+          {
+            error:
+              "Invalid file type. Allowed types: JPEG, PNG, GIF, WebP, SVG",
+          },
+          { status: 400 }
+        );
+      }
+
+      const uploadsDir = join(process.cwd(), "uploads");
+      if (!existsSync(uploadsDir)) {
+        await mkdir(uploadsDir, { recursive: true });
+      }
+
+      const timestamp = Date.now();
+      const originalName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_");
+      const filename = `${id}-${timestamp}-${originalName}`;
+
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const filepath = join(uploadsDir, filename);
+      await writeFile(filepath, buffer);
+
+      const imageUrl = `/api/uploads/${filename}`;
+
+      await prisma.product.update({
+        where: { id },
+        data: { imageUrl },
+      });
+
+      const isSvg = file.type === "image/svg+xml" || file.name.endsWith(".svg");
+      if (isSvg) {
+        const content = buffer.toString("utf-8");
+        if (containsMaliciousContent(content)) {
+          const flag = await prisma.flag.findUnique({
+            where: { slug: "malicious-file-upload" },
+          });
+
+          return NextResponse.json({
+            message: "Image uploaded successfully",
+            imageUrl,
+            productName: product.name,
+            flag: flag?.flag,
+          });
+        }
+      }
+
+      return NextResponse.json({
+        message: "Image uploaded successfully",
+        imageUrl,
+        productName: product.name,
+      });
+    } catch (error) {
+      console.error("Error uploading image:", error);
+      return NextResponse.json(
+        { error: "Failed to upload image" },
+        { status: 500 }
+      );
+    }
   }
-}
+);

--- a/app/api/admin/products/route.ts
+++ b/app/api/admin/products/route.ts
@@ -1,19 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAdminAuth } from "@/lib/server-auth";
 
-export async function GET(request: NextRequest) {
+export const GET = withAdminAuth(async (_request, _context, _user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
     const products = await prisma.product.findMany({
       orderBy: { name: "asc" },
     });
@@ -26,4 +16,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/admin/reviews/route.ts
+++ b/app/api/admin/reviews/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAdminAuth } from "@/lib/server-auth";
 import Database from "better-sqlite3";
 import { getDatabaseUrl } from "@/lib/database";
 
@@ -37,74 +37,65 @@ function getDbPath(): string {
   return url.replace(/^file:/, "");
 }
 
-export async function GET(request: NextRequest) {
-  const user = await getAuthenticatedUser(request);
+export const GET = withAdminAuth(
+  async (request: NextRequest, _context, _user) => {
+    try {
+      const { searchParams } = new URL(request.url);
+      const authorFilter = searchParams.get("author");
 
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+      const authors = await prisma.review.findMany({
+        select: { author: true },
+        distinct: ["author"],
+        orderBy: { author: "asc" },
+      });
 
-  if (user.role !== "ADMIN") {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+      const distinctAuthors = authors.map((a) => a.author);
 
-  try {
-    const { searchParams } = new URL(request.url);
-    const authorFilter = searchParams.get("author");
+      let flag: string | null = null;
+      let sqlInjectionDetected = false;
 
-    const authors = await prisma.review.findMany({
-      select: { author: true },
-      distinct: ["author"],
-      orderBy: { author: "asc" },
-    });
+      if (authorFilter) {
+        sqlInjectionDetected = isSQLInjectionAttempt(authorFilter);
 
-    const distinctAuthors = authors.map((a) => a.author);
+        const upperFilter = authorFilter.toUpperCase();
+        const normalizedFilter = upperFilter.replace(/\s+/g, " ");
+        const isAccessingFlagsTable =
+          normalizedFilter.includes("FROM FLAGS") ||
+          normalizedFilter.includes("FROM`FLAGS`") ||
+          normalizedFilter.includes('FROM"FLAGS"') ||
+          normalizedFilter.includes("JOIN FLAGS") ||
+          normalizedFilter.includes("JOIN`FLAGS`") ||
+          normalizedFilter.includes('JOIN"FLAGS"') ||
+          normalizedFilter.includes("FLAGS WHERE") ||
+          normalizedFilter.includes("FLAGS.") ||
+          /FLAGS\s*[,\s]/.test(normalizedFilter);
 
-    let flag: string | null = null;
-    let sqlInjectionDetected = false;
+        if (isAccessingFlagsTable) {
+          return NextResponse.json(
+            {
+              error:
+                "Access to flags table is not allowed... Well, that's a shame... You'll have to find another way to get them all...",
+              reviews: [],
+              authors: distinctAuthors,
+            },
+            { status: 403 }
+          );
+        }
 
-    if (authorFilter) {
-      sqlInjectionDetected = isSQLInjectionAttempt(authorFilter);
-
-      const upperFilter = authorFilter.toUpperCase();
-      const normalizedFilter = upperFilter.replace(/\s+/g, " ");
-      const isAccessingFlagsTable =
-        normalizedFilter.includes("FROM FLAGS") ||
-        normalizedFilter.includes("FROM`FLAGS`") ||
-        normalizedFilter.includes('FROM"FLAGS"') ||
-        normalizedFilter.includes("JOIN FLAGS") ||
-        normalizedFilter.includes("JOIN`FLAGS`") ||
-        normalizedFilter.includes('JOIN"FLAGS"') ||
-        normalizedFilter.includes("FLAGS WHERE") ||
-        normalizedFilter.includes("FLAGS.") ||
-        /FLAGS\s*[,\s]/.test(normalizedFilter);
-
-      if (isAccessingFlagsTable) {
-        return NextResponse.json(
-          {
-            error:
-              "Access to flags table is not allowed... Well, that's a shame... You'll have to find another way to get them all...",
-            reviews: [],
-            authors: distinctAuthors,
-          },
-          { status: 403 }
-        );
-      }
-
-      if (sqlInjectionDetected) {
-        const sqlInjectionFlag = await prisma.flag.findUnique({
-          where: { slug: "second-order-sql-injection" },
-        });
-        if (sqlInjectionFlag) {
-          flag = sqlInjectionFlag.flag;
+        if (sqlInjectionDetected) {
+          const sqlInjectionFlag = await prisma.flag.findUnique({
+            where: { slug: "second-order-sql-injection" },
+          });
+          if (sqlInjectionFlag) {
+            flag = sqlInjectionFlag.flag;
+          }
         }
       }
-    }
 
-    let reviews: Record<string, unknown>[];
+      let reviews: Record<string, unknown>[];
 
-    if (authorFilter) {
-      const query = `
+      if (authorFilter) {
+        const query = `
         SELECT
           r.id,
           r."productId",
@@ -118,14 +109,14 @@ export async function GET(request: NextRequest) {
         ORDER BY r."createdAt" DESC
       `;
 
-      let queryResults: Record<string, unknown>[] = [];
-      const db = new Database(getDbPath());
-      try {
-        db.exec(query);
+        let queryResults: Record<string, unknown>[] = [];
+        const db = new Database(getDbPath());
         try {
-          queryResults = db
-            .prepare(
-              `SELECT
+          db.exec(query);
+          try {
+            queryResults = db
+              .prepare(
+                `SELECT
                 r.id,
                 r."productId",
                 r.content,
@@ -136,75 +127,76 @@ export async function GET(request: NextRequest) {
               INNER JOIN products p ON r."productId" = p.id
               WHERE r.author = '${authorFilter}'
               ORDER BY r."createdAt" DESC`
-            )
-            .all() as Record<string, unknown>[];
+              )
+              .all() as Record<string, unknown>[];
+          } catch {
+            queryResults = [];
+          }
         } catch {
           queryResults = [];
+        } finally {
+          db.close();
         }
-      } catch {
-        queryResults = [];
-      } finally {
-        db.close();
+
+        reviews = queryResults
+          .map((row: Record<string, unknown>) => {
+            const result: Record<string, unknown> = {};
+            for (const key in row) {
+              const value = row[key];
+              if (
+                typeof value === "string" &&
+                (value.toLowerCase().includes("flags") ||
+                  value.toLowerCase().includes("oss{"))
+              ) {
+                continue;
+              }
+              result[key] = value;
+            }
+            return result;
+          })
+          .filter((row) => Object.keys(row).length > 0);
+      } else {
+        const safeReviews = await prisma.review.findMany({
+          include: {
+            product: {
+              select: { name: true },
+            },
+          },
+          orderBy: { createdAt: "desc" },
+        });
+
+        reviews = safeReviews.map((r) => ({
+          id: r.id,
+          productId: r.productId,
+          content: r.content,
+          author: r.author,
+          createdAt: r.createdAt,
+          productName: r.product.name,
+        }));
       }
 
-      reviews = queryResults
-        .map((row: Record<string, unknown>) => {
-          const result: Record<string, unknown> = {};
-          for (const key in row) {
-            const value = row[key];
-            if (
-              typeof value === "string" &&
-              (value.toLowerCase().includes("flags") ||
-                value.toLowerCase().includes("oss{"))
-            ) {
-              continue;
-            }
-            result[key] = value;
-          }
-          return result;
-        })
-        .filter((row) => Object.keys(row).length > 0);
-    } else {
-      const safeReviews = await prisma.review.findMany({
-        include: {
-          product: {
-            select: { name: true },
-          },
-        },
-        orderBy: { createdAt: "desc" },
-      });
+      const response: {
+        reviews: Record<string, unknown>[];
+        authors: string[];
+        flag?: string;
+        message?: string;
+      } = {
+        reviews,
+        authors: distinctAuthors,
+      };
 
-      reviews = safeReviews.map((r) => ({
-        id: r.id,
-        productId: r.productId,
-        content: r.content,
-        author: r.author,
-        createdAt: r.createdAt,
-        productName: r.product.name,
-      }));
+      if (sqlInjectionDetected && flag) {
+        response.flag = flag;
+        response.message = "SQL injection detected in stored review author";
+      }
+
+      return NextResponse.json(response);
+    } catch (error) {
+      console.error("Error fetching reviews:", error);
+      return NextResponse.json(
+        { error: "Failed to fetch reviews" },
+        { status: 500 }
+      );
     }
-
-    const response: {
-      reviews: Record<string, unknown>[];
-      authors: string[];
-      flag?: string;
-      message?: string;
-    } = {
-      reviews,
-      authors: distinctAuthors,
-    };
-
-    if (sqlInjectionDetected && flag) {
-      response.flag = flag;
-      response.message = "SQL injection detected in stored review author";
-    }
-
-    return NextResponse.json(response);
-  } catch (error) {
-    console.error("Error fetching reviews:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch reviews" },
-      { status: 500 }
-    );
   }
-}
+);

--- a/app/api/admin/route.ts
+++ b/app/api/admin/route.ts
@@ -1,33 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { decodeWeakJWT } from "@/lib/server-auth";
+import { withAdminAuth } from "@/lib/server-auth";
 
-interface ExtendedJWTPayload {
-  id: string;
-  email: string;
-  role: string;
-  exp: number;
-  supportAccess?: boolean;
-}
-
-export async function GET(request: NextRequest) {
+export const GET = withAdminAuth(async (_request, _context, user) => {
   try {
-    const token = request.cookies.get("authToken")?.value ?? null;
-
-    if (!token) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const user = decodeWeakJWT(token) as ExtendedJWTPayload | null;
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
     const dbUser = await prisma.user.findUnique({
       where: { id: user.id },
       select: { id: true, email: true, role: true },
@@ -124,4 +100,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/admin/suppliers/import-order/route.ts
+++ b/app/api/admin/suppliers/import-order/route.ts
@@ -1,100 +1,95 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAdminAuth } from "@/lib/server-auth";
 import { prisma } from "@/lib/prisma";
 import libxmljs from "libxmljs2";
 import path from "path";
 
 const SUPPLIER_REGISTRY_PATH = path.join(process.cwd(), "flag-xxe.txt");
 
-export async function POST(request: NextRequest) {
-  const user = await getAuthenticatedUser(request);
+export const POST = withAdminAuth(
+  async (request: NextRequest, _context, _user) => {
+    try {
+      const rawXml = await request.text();
 
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+      if (!rawXml.trim()) {
+        return NextResponse.json(
+          { error: "Empty request body. Please provide XML data." },
+          { status: 400 }
+        );
+      }
 
-  if (user.role !== "ADMIN") {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+      const doc = libxmljs.parseXmlString(rawXml, {
+        noent: true,
+        dtdload: true,
+      });
 
-  try {
-    const rawXml = await request.text();
-
-    if (!rawXml.trim()) {
-      return NextResponse.json(
-        { error: "Empty request body. Please provide XML data." },
-        { status: 400 }
-      );
-    }
-
-    const doc = libxmljs.parseXmlString(rawXml, { noent: true, dtdload: true });
-
-    const root = doc.root();
-    if (!root || root.name() !== "order") {
-      return NextResponse.json(
-        {
-          error: "Invalid XML structure. Expected root element <order>.",
-          debug: {
-            config: SUPPLIER_REGISTRY_PATH,
-            message: "The XML must match the supplier order schema.",
-            expected: ["supplierId", "orderId", "total", "notes (optional)"],
-          },
-        },
-        { status: 400 }
-      );
-    }
-
-    const getText = (name: string) =>
-      (root.get(name) as libxmljs.Element | null)?.text()?.trim() || "";
-
-    const supplierId = getText("supplierId");
-    const orderId = getText("orderId");
-    const total = parseFloat(getText("total")) || 0;
-    const notes = getText("notes");
-
-    if (!supplierId || !orderId) {
-      return NextResponse.json(
-        {
-          error: "Missing required fields: supplierId and orderId.",
-          debug: {
-            config: SUPPLIER_REGISTRY_PATH,
-            received: {
-              supplierId: supplierId || null,
-              orderId: orderId || null,
+      const root = doc.root();
+      if (!root || root.name() !== "order") {
+        return NextResponse.json(
+          {
+            error: "Invalid XML structure. Expected root element <order>.",
+            debug: {
+              config: SUPPLIER_REGISTRY_PATH,
+              message: "The XML must match the supplier order schema.",
+              expected: ["supplierId", "orderId", "total", "notes (optional)"],
             },
           },
+          { status: 400 }
+        );
+      }
+
+      const getText = (name: string) =>
+        (root.get(name) as libxmljs.Element | null)?.text()?.trim() || "";
+
+      const supplierId = getText("supplierId");
+      const orderId = getText("orderId");
+      const total = parseFloat(getText("total")) || 0;
+      const notes = getText("notes");
+
+      if (!supplierId || !orderId) {
+        return NextResponse.json(
+          {
+            error: "Missing required fields: supplierId and orderId.",
+            debug: {
+              config: SUPPLIER_REGISTRY_PATH,
+              received: {
+                supplierId: supplierId || null,
+                orderId: orderId || null,
+              },
+            },
+          },
+          { status: 400 }
+        );
+      }
+
+      const supplierOrder = await prisma.supplierOrder.create({
+        data: {
+          supplierId,
+          orderId,
+          total,
+          notes: notes || null,
+        },
+      });
+
+      return NextResponse.json({
+        message: "Supplier order imported successfully.",
+        order: {
+          id: supplierOrder.id,
+          supplierId: supplierOrder.supplierId,
+          orderId: supplierOrder.orderId,
+          total: supplierOrder.total,
+          notes: supplierOrder.notes,
+          createdAt: supplierOrder.createdAt,
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return NextResponse.json(
+        {
+          error: `Failed to parse XML: ${message}`,
         },
         { status: 400 }
       );
     }
-
-    const supplierOrder = await prisma.supplierOrder.create({
-      data: {
-        supplierId,
-        orderId,
-        total,
-        notes: notes || null,
-      },
-    });
-
-    return NextResponse.json({
-      message: "Supplier order imported successfully.",
-      order: {
-        id: supplierOrder.id,
-        supplierId: supplierOrder.supplierId,
-        orderId: supplierOrder.orderId,
-        total: supplierOrder.total,
-        notes: supplierOrder.notes,
-        createdAt: supplierOrder.createdAt,
-      },
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
-    return NextResponse.json(
-      {
-        error: `Failed to parse XML: ${message}`,
-      },
-      { status: 400 }
-    );
   }
-}
+);

--- a/app/api/admin/suppliers/route.ts
+++ b/app/api/admin/suppliers/route.ts
@@ -1,21 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { withAdminAuth } from "@/lib/server-auth";
 
-export async function GET(request: NextRequest) {
-  const user = await getAuthenticatedUser(request);
-
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  if (user.role !== "ADMIN") {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
+export const GET = withAdminAuth(async (_request, _context, _user) => {
   const orders = await prisma.supplierOrder.findMany({
     orderBy: { createdAt: "desc" },
   });
 
   return NextResponse.json(orders);
-}
+});

--- a/app/api/admin/support-audit/route.ts
+++ b/app/api/admin/support-audit/route.ts
@@ -1,36 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { decodeWeakJWT } from "@/lib/server-auth";
+import { withAdminAuth } from "@/lib/server-auth";
 
-interface ExtendedJWTPayload {
-  id: string;
-  email: string;
-  role: string;
-  exp: number;
-  supportAccess?: boolean;
-}
-
-export async function GET(request: NextRequest) {
+export const GET = withAdminAuth(async (_request, _context, user) => {
   try {
-    const token = request.cookies.get("authToken")?.value ?? null;
-
-    if (!token) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const payload = decodeWeakJWT(token) as ExtendedJWTPayload | null;
-
-    if (!payload) {
-      return NextResponse.json({ error: "Invalid token" }, { status: 401 });
-    }
-
-    if (payload.role !== "ADMIN") {
-      return NextResponse.json(
-        { error: "Admin access required" },
-        { status: 403 }
-      );
-    }
-
     const supportTokens = await prisma.supportAccessToken.findMany({
       orderBy: { createdAt: "desc" },
       take: 50,
@@ -56,7 +29,7 @@ export async function GET(request: NextRequest) {
       totalCount: supportTokens.length,
     };
 
-    if (payload.supportAccess) {
+    if (user.supportAccess) {
       const flag = await prisma.flag.findUnique({
         where: { slug: "session-fixation-weak-session-management" },
       });
@@ -78,4 +51,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/cart/add/route.ts
+++ b/app/api/cart/add/route.ts
@@ -1,15 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json();
     const { productId, quantity } = body;
 
@@ -71,4 +65,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/cart/items/[id]/route.ts
+++ b/app/api/cart/items/[id]/route.ts
@@ -1,19 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const DELETE = withAuth(async (_request, context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id } = await params;
+    const { id } = await context.params;
 
     const cartItem = await prisma.cartItem.findUnique({
       where: { id },
@@ -45,20 +36,11 @@ export async function DELETE(
       { status: 500 }
     );
   }
-}
+});
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const PATCH = withAuth(async (request: NextRequest, context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id } = await params;
+    const { id } = await context.params;
     const body = await request.json();
     const { quantity } = body;
 
@@ -100,4 +82,4 @@ export async function PATCH(
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/cart/route.ts
+++ b/app/api/cart/route.ts
@@ -1,15 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (_request, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const cart = await prisma.cart.findFirst({
       where: { userId: user.id },
       include: {
@@ -56,4 +50,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/coupon/[code]/route.ts
+++ b/app/api/coupon/[code]/route.ts
@@ -1,19 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ code: string }> }
-) {
+export const GET = withAuth(async (_request, context, _user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { code } = await params;
+    const { code } = await context.params;
 
     const coupon = await prisma.coupon.findUnique({
       where: { code: code.toUpperCase() },
@@ -40,4 +31,4 @@ export async function GET(
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/coupon/apply/route.ts
+++ b/app/api/coupon/apply/route.ts
@@ -1,15 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, _context, _user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json();
     const { code, cartTotal } = body;
 
@@ -62,4 +56,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/orders/[id]/route.ts
+++ b/app/api/orders/[id]/route.ts
@@ -1,19 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth, type JWTPayload } from "@/lib/server-auth";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const GET = withAuth(async (_request, context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id } = await params;
+    const { id } = await context.params;
 
     const order = await prisma.order.findUnique({
       where: { id },
@@ -75,19 +66,14 @@ export async function GET(
       { status: 500 }
     );
   }
-}
+});
 
 const updateOrderStatus = async (
   request: NextRequest,
-  orderId: string
+  orderId: string,
+  user: JWTPayload
 ): Promise<NextResponse> => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     if (user.role !== "ADMIN") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -183,18 +169,12 @@ const updateOrderStatus = async (
   }
 };
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  return updateOrderStatus(request, id);
-}
+export const PATCH = withAuth(async (request: NextRequest, context, user) => {
+  const { id } = await context.params;
+  return updateOrderStatus(request, id, user);
+});
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  return updateOrderStatus(request, id);
-}
+export const POST = withAuth(async (request: NextRequest, context, user) => {
+  const { id } = await context.params;
+  return updateOrderStatus(request, id, user);
+});

--- a/app/api/orders/[id]/share/route.ts
+++ b/app/api/orders/[id]/share/route.ts
@@ -1,20 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 import { encryptShareToken } from "@/lib/share-crypto";
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const POST = withAuth(async (request: NextRequest, context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id } = await params;
+    const { id } = await context.params;
 
     const order = await prisma.order.findUnique({
       where: { id, userId: user.id },
@@ -38,4 +29,4 @@ export async function POST(
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,20 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth, withAdminAuth } from "@/lib/server-auth";
 import { generateInvoice } from "@/lib/invoice";
 
-export async function GET(request: NextRequest) {
+export const GET = withAdminAuth(async (_request, _context, _user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
     const orders = await prisma.order.findMany({
       include: {
         user: {
@@ -37,16 +27,10 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json();
     const { total, couponCode } = body;
 
@@ -232,4 +216,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/orders/search/route.ts
+++ b/app/api/orders/search/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
 const isSQLInjectionAttempt = (input: string): boolean => {
   const sqlKeywords = [
@@ -30,14 +30,8 @@ const isSQLInjectionAttempt = (input: string): boolean => {
   return sqlKeywords.some((keyword) => upperInput.includes(keyword));
 };
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json();
     const { status } = body;
 
@@ -84,7 +78,7 @@ export async function POST(request: NextRequest) {
       status && typeof status === "string" ? `AND o.status = '${status}'` : "";
 
     const query = `
-      SELECT 
+      SELECT
         o.id,
         o.total,
         o.status,
@@ -149,4 +143,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/user/export/route.ts
+++ b/app/api/user/export/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
 const ALLOWED_USER_FIELDS = ["id", "email", "role", "addressId", "password"];
 
@@ -58,14 +58,8 @@ async function getSystemDiagnostics() {
   return diagnostics;
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json();
     const { format, fields } = body;
 
@@ -157,4 +151,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -1,14 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (_request, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const dbUser = await prisma.user.findUnique({
       where: { id: user.id },
       select: {
@@ -54,15 +49,10 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     let displayName: string | undefined;
     let bio: string | undefined;
     const contentType = request.headers.get("content-type") || "";
@@ -125,4 +115,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,15 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (_request, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const dbUser = await prisma.user.findUnique({
       where: { id: user.id },
       include: {
@@ -44,4 +38,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/user/support-access/route.ts
+++ b/app/api/user/support-access/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 import crypto from "crypto";
 
 const TOKEN_EXPIRY_DAYS = 365;
@@ -9,14 +9,8 @@ function generateSecureToken(): string {
   return crypto.randomBytes(32).toString("hex");
 }
 
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (_request, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const supportToken = await prisma.supportAccessToken.findFirst({
       where: {
         userId: user.id,
@@ -46,16 +40,10 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json().catch(() => ({}));
 
     const targetEmail = body.email || user.email;
@@ -99,16 +87,10 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});
 
-export async function DELETE(request: NextRequest) {
+export const DELETE = withAuth(async (_request, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     await prisma.supportAccessToken.updateMany({
       where: {
         userId: user.id,
@@ -129,4 +111,4 @@ export async function DELETE(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/wishlists/[id]/items/[itemId]/route.ts
+++ b/app/api/wishlists/[id]/items/[itemId]/route.ts
@@ -1,19 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string; itemId: string }> }
-) {
+export const DELETE = withAuth(async (_request, context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id, itemId } = await params;
+    const { id, itemId } = await context.params;
 
     const wishlist = await prisma.wishlist.findUnique({
       where: { id },
@@ -53,4 +44,4 @@ export async function DELETE(
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/wishlists/[id]/items/route.ts
+++ b/app/api/wishlists/[id]/items/route.ts
@@ -1,19 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const POST = withAuth(async (request: NextRequest, context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id } = await params;
+    const { id } = await context.params;
 
     const wishlist = await prisma.wishlist.findUnique({
       where: { id },
@@ -87,4 +78,4 @@ export async function POST(
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/wishlists/[id]/route.ts
+++ b/app/api/wishlists/[id]/route.ts
@@ -1,19 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const GET = withAuth(async (_request, context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id } = await params;
+    const { id } = await context.params;
 
     const wishlist = await prisma.wishlist.findUnique({
       where: { id },
@@ -94,20 +85,11 @@ export async function GET(
       { status: 500 }
     );
   }
-}
+});
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export const DELETE = withAuth(async (_request, context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id } = await params;
+    const { id } = await context.params;
 
     const wishlist = await prisma.wishlist.findUnique({
       where: { id },
@@ -136,4 +118,4 @@ export async function DELETE(
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/wishlists/route.ts
+++ b/app/api/wishlists/route.ts
@@ -1,15 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getAuthenticatedUser } from "@/lib/server-auth";
+import { withAuth } from "@/lib/server-auth";
 
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (_request, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const wishlists = await prisma.wishlist.findMany({
       where: { userId: user.id },
       select: {
@@ -35,16 +29,10 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, _context, user) => {
   try {
-    const user = await getAuthenticatedUser(request);
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const body = await request.json();
     const { name } = body;
 
@@ -77,4 +65,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,10 @@ const eslintConfig = defineConfig([
     },
     rules: {
       "prettier/prettier": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
     },
   },
   globalIgnores([

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 
-interface JWTPayload {
+export interface JWTPayload {
   id: string;
   email: string;
   role: string;
@@ -85,5 +85,36 @@ export function clearAuthCookie(response: NextResponse): void {
     sameSite: "lax",
     maxAge: 0,
     path: "/",
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RouteContext = { params: Promise<any> };
+
+type AuthenticatedHandler = (
+  request: NextRequest,
+  context: RouteContext,
+  user: JWTPayload
+) => Promise<NextResponse>;
+
+export function withAuth(handler: AuthenticatedHandler) {
+  return async (
+    request: NextRequest,
+    context: RouteContext
+  ): Promise<NextResponse> => {
+    const user = await getAuthenticatedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return handler(request, context, user);
+  };
+}
+
+export function withAdminAuth(handler: AuthenticatedHandler) {
+  return withAuth(async (request, context, user) => {
+    if (user.role !== "ADMIN") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handler(request, context, user);
   });
 }


### PR DESCRIPTION
## Description

Replace repetitive manual `getAuthenticatedUser()` + null-check + role-check boilerplate across all 26 API route files with two composable higher-order functions: `withAuth` and `withAdminAuth`.

- `withAuth(handler)` extracts the user from the cookie and returns 401 if missing
- `withAdminAuth(handler)` composes on `withAuth` and adds a 403 if `role !== "ADMIN"`
- The authenticated user is passed as the third argument to the handler: `(request, context, user)`

Net result: **-236 lines** of duplicated auth logic, no behavioral changes.

Issue: https://github.com/kOaDT/oss-oopssec-store/issues/81

## Type of change

- [ ] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [ ] Documentation update
- [x] Other (please describe): Refactoring — DRY up authentication boilerplate across API routes

## Testing done

- Verified all route handlers maintain identical auth behavior (401/403 responses)
- Confirmed `supportAccess` field remains accessible through `JWTPayload` type on routes that use it (`/api/admin/route.ts`, `/api/admin/support-audit/route.ts`)

## Checklist

- [x] Documentation updated (if applicable)
  - `.cursor/rules/api-patterns.mdc` updated to reflect the new `withAuth`/`withAdminAuth` pattern
