### PR TITLE
feat: add server-side pagination to SIEM log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,6 @@ Found all the flags? Open a pull request to join the [Hall of Fame](hall-of-fame
 
 <div align="center">
 
-<a href="https://github.com/kOaDT/oss-oopssec-store">
-  <img src="https://images.repography.com/103508692/kOaDT/oss-oopssec-store/structure/Q7MububoYUVlm99MQWYW12szb_gGlehkuutaTn9WlA4/xqocpGlYz1v1FH126K5mqp7WjOcy1VH9pbA-EuINusA_table.svg" alt="Structure">
-</a>
-
 </div>
 
 | Folder                     | Description                                                    |

--- a/app/api/monitoring/logs/route.ts
+++ b/app/api/monitoring/logs/route.ts
@@ -23,6 +23,18 @@ function isAuthenticated(request: NextRequest): boolean {
   return false;
 }
 
+function parseLine(line: string) {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return {
+      timestamp: new Date().toISOString(),
+      level: "log",
+      message: line,
+    };
+  }
+}
+
 export async function GET(request: NextRequest) {
   if (!isAuthenticated(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -31,26 +43,44 @@ export async function GET(request: NextRequest) {
   const logFile = path.join(process.cwd(), "logs", "app.log");
 
   if (!fs.existsSync(logFile)) {
-    return NextResponse.json({ logs: [] });
+    return NextResponse.json({ logs: [], total: 0, page: 1, totalPages: 0 });
   }
 
   try {
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+    const limit = Math.min(
+      200,
+      Math.max(1, parseInt(searchParams.get("limit") || "100", 10))
+    );
+    const level = searchParams.get("level") || "";
+    const search = searchParams.get("search") || "";
+
     const content = fs.readFileSync(logFile, "utf-8");
     const lines = content.trim().split("\n").filter(Boolean);
 
-    const logs = lines.map((line) => {
-      try {
-        return JSON.parse(line);
-      } catch {
-        return {
-          timestamp: new Date().toISOString(),
-          level: "log",
-          message: line,
-        };
-      }
-    });
+    let parsed = lines.map(parseLine);
 
-    return NextResponse.json({ logs });
+    if (level || search) {
+      const searchLower = search.toLowerCase();
+      parsed = parsed.filter((entry) => {
+        if (level && entry.level !== level) return false;
+        if (
+          search &&
+          !(entry.message ?? "").toLowerCase().includes(searchLower)
+        )
+          return false;
+        return true;
+      });
+    }
+
+    const total = parsed.length;
+    const totalPages = Math.ceil(total / limit);
+    const start = total - page * limit;
+    const end = total - (page - 1) * limit;
+    const logs = parsed.slice(Math.max(0, start), end).reverse();
+
+    return NextResponse.json({ logs, total, page, totalPages });
   } catch {
     return NextResponse.json({ error: "Failed to read logs" }, { status: 500 });
   }

--- a/app/monitoring/siem/page.tsx
+++ b/app/monitoring/siem/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 interface LogEntry {
   timestamp: string;
@@ -122,26 +122,107 @@ const LEVEL_BADGE_STYLES: Record<string, string> = {
   log: "bg-slate-800/40 text-slate-400 border-slate-700/50",
 };
 
+const PAGE_BTN =
+  "rounded border border-slate-700 bg-slate-800 px-2.5 py-1 font-mono text-xs text-slate-400 transition-colors hover:bg-slate-700 cursor-pointer disabled:cursor-not-allowed disabled:opacity-40";
+
+function Pagination({
+  page,
+  totalPages,
+  total,
+  onPageChange,
+}: {
+  page: number;
+  totalPages: number;
+  total: number;
+  onPageChange: (p: number) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between border-t border-slate-700/50 px-3 py-3">
+      <span className="font-mono text-xs text-slate-500">
+        {total.toLocaleString()} entries — page {page} of {totalPages}
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => onPageChange(1)}
+          disabled={page <= 1}
+          className={PAGE_BTN}
+        >
+          First
+        </button>
+        <button
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+          disabled={page <= 1}
+          className={PAGE_BTN}
+        >
+          Prev
+        </button>
+        <button
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+          disabled={page >= totalPages}
+          className={PAGE_BTN}
+        >
+          Next
+        </button>
+        <button
+          onClick={() => onPageChange(totalPages)}
+          disabled={page >= totalPages}
+          className={PAGE_BTN}
+        >
+          Last
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function Dashboard() {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState("");
+  const [debouncedFilter, setDebouncedFilter] = useState("");
   const [levelFilter, setLevelFilter] = useState<string>("all");
   const [autoRefresh, setAutoRefresh] = useState(true);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+  const [total, setTotal] = useState(0);
+  const LIMIT = 100;
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleFilterChange = (value: string) => {
+    setFilter(value);
+    setPage(1);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setDebouncedFilter(value), 300);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
 
   const fetchLogs = useCallback(async () => {
     try {
-      const res = await fetch("/api/monitoring/logs");
+      const params = new URLSearchParams({
+        page: String(page),
+        limit: String(LIMIT),
+      });
+      if (levelFilter !== "all") params.set("level", levelFilter);
+      if (debouncedFilter) params.set("search", debouncedFilter);
+
+      const res = await fetch(`/api/monitoring/logs?${params}`);
       if (res.ok) {
         const data = await res.json();
         setLogs(data.logs || []);
+        setTotalPages(data.totalPages || 0);
+        setTotal(data.total || 0);
       }
     } catch {
       // Silently handle fetch errors
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [page, levelFilter, debouncedFilter]);
 
   useEffect(() => {
     fetchLogs();
@@ -152,13 +233,6 @@ function Dashboard() {
     const interval = setInterval(fetchLogs, 5000);
     return () => clearInterval(interval);
   }, [autoRefresh, fetchLogs]);
-
-  const filteredLogs = logs.filter((log) => {
-    if (levelFilter !== "all" && log.level !== levelFilter) return false;
-    if (filter && !log.message.toLowerCase().includes(filter.toLowerCase()))
-      return false;
-    return true;
-  });
 
   return (
     <div className="min-h-screen bg-[#0a0e17] text-slate-200">
@@ -195,7 +269,7 @@ function Dashboard() {
               </span>
             </div>
             <span className="font-mono text-xs text-slate-600">
-              {logs.length} entries
+              {total.toLocaleString()} entries
             </span>
           </div>
         </div>
@@ -206,13 +280,16 @@ function Dashboard() {
           <input
             type="text"
             value={filter}
-            onChange={(e) => setFilter(e.target.value)}
+            onChange={(e) => handleFilterChange(e.target.value)}
             placeholder="Search logs..."
             className="w-64 rounded border border-slate-700 bg-[#0a0e17] px-3 py-1.5 font-mono text-sm text-slate-200 outline-none placeholder:text-slate-600 focus:border-cyan-600"
           />
           <select
             value={levelFilter}
-            onChange={(e) => setLevelFilter(e.target.value)}
+            onChange={(e) => {
+              setLevelFilter(e.target.value);
+              setPage(1);
+            }}
             className="rounded border border-slate-700 bg-[#0a0e17] px-3 py-1.5 font-mono text-sm text-slate-200 outline-none focus:border-cyan-600"
           >
             <option value="all">All Levels</option>
@@ -240,61 +317,72 @@ function Dashboard() {
         </div>
       </div>
 
-      <div className="px-6 py-4">
+      <div className="px-6 py-4 pb-24">
         {loading ? (
           <div className="flex items-center justify-center py-20">
             <div className="font-mono text-sm text-slate-600">
               Loading logs...
             </div>
           </div>
-        ) : filteredLogs.length === 0 ? (
+        ) : logs.length === 0 ? (
           <div className="flex items-center justify-center py-20">
             <div className="font-mono text-sm text-slate-600">
               No log entries found
             </div>
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full font-mono text-sm">
-              <thead>
-                <tr className="border-b border-slate-700/50 text-left">
-                  <th className="px-3 py-2 text-xs font-medium text-slate-500">
-                    Timestamp
-                  </th>
-                  <th className="px-3 py-2 text-xs font-medium text-slate-500">
-                    Level
-                  </th>
-                  <th className="px-3 py-2 text-xs font-medium text-slate-500">
-                    Message
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredLogs.map((log, i) => (
-                  <tr
-                    key={i}
-                    className="border-b border-slate-800/50 transition-colors hover:bg-slate-800/30"
-                  >
-                    <td className="whitespace-nowrap px-3 py-2 text-xs text-slate-500">
-                      {new Date(log.timestamp).toLocaleString()}
-                    </td>
-                    <td className="px-3 py-2">
-                      <span
-                        className={`inline-block rounded border px-2 py-0.5 text-xs font-medium uppercase ${LEVEL_BADGE_STYLES[log.level] || LEVEL_BADGE_STYLES.log}`}
-                      >
-                        {log.level}
-                      </span>
-                    </td>
-                    <td
-                      className={`max-w-2xl break-all px-3 py-2 text-xs ${LEVEL_STYLES[log.level] || LEVEL_STYLES.log}`}
-                    >
-                      {log.message}
-                    </td>
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full font-mono text-sm">
+                <thead>
+                  <tr className="border-b border-slate-700/50 text-left">
+                    <th className="px-3 py-2 text-xs font-medium text-slate-500">
+                      Timestamp
+                    </th>
+                    <th className="px-3 py-2 text-xs font-medium text-slate-500">
+                      Level
+                    </th>
+                    <th className="px-3 py-2 text-xs font-medium text-slate-500">
+                      Message
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {logs.map((log, i) => (
+                    <tr
+                      key={i}
+                      className="border-b border-slate-800/50 transition-colors hover:bg-slate-800/30"
+                    >
+                      <td className="whitespace-nowrap px-3 py-2 text-xs text-slate-500">
+                        {new Date(log.timestamp).toLocaleString()}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`inline-block rounded border px-2 py-0.5 text-xs font-medium uppercase ${LEVEL_BADGE_STYLES[log.level] || LEVEL_BADGE_STYLES.log}`}
+                        >
+                          {log.level}
+                        </span>
+                      </td>
+                      <td
+                        className={`max-w-2xl break-all px-3 py-2 text-xs ${LEVEL_STYLES[log.level] || LEVEL_STYLES.log}`}
+                      >
+                        {log.message}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {totalPages > 1 && (
+              <Pagination
+                page={page}
+                totalPages={totalPages}
+                total={total}
+                onPageChange={setPage}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6753,6 +6753,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",


### PR DESCRIPTION
## Description

The SIEM log viewer (`/monitoring/siem`) was loading all log entries from `app.log` at once — both in the API response and in the DOM. With thousands entries in local dev, this caused major performance issues (slow responses, high memory usage, unresponsive UI).

This adds server-side pagination with filtering:
- API accepts `page`, `limit`, `level`, and `search` query params
- Returns only the requested page, newest first
- Frontend pagination controls (First / Prev / Next / Last)
- Search input is debounced (300ms) to avoid excessive API calls
- Pagination component extracted for reuse and readability

## Type of change

- [x] Bug fix

## Testing done

- Verified pagination navigates correctly across pages
- Tested level filter and search filter reset page to 1
- Confirmed auto-refresh keeps working on the current page
- Checked edge cases: empty log file, single page of results (no pagination shown), last page with fewer entries

## Checklist

- [x] Documentation updated (if applicable)
