### PR TITLE
fix: include packages/react-toastfy in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 docs/
-packages/
+packages/create-oss-store/
 tests/
 cypress/
 .cursor/


### PR DESCRIPTION
## Description

The supply-chain challenge relies on reading `packages/react-toastfy/*` via the path-traversal endpoint. The previous `.dockerignore` excluded the entire `packages/` directory, making the challenge unreachable when the lab was started via docker. Narrow the exclusion to `packages/create-oss-store/` so the typosquatted package ships with the image while the CLI scaffolder stays out.

## Type of change

- [x] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [ ] Documentation update
- [ ] Other (please describe):

## Testing done

- Ran `docker compose build --no-cache && docker compose up`, then `curl -s "http://localhost:3000/api/files?file=../packages/react-toastfy/package.json"` — now returns the poisoned `package.json` instead of `{"error":"Failed to read file"}`.
- Verified `packages/create-oss-store/` is still excluded from the image (no leakage of the CLI scaffolder).
- Re-ran the full supply-chain walkthrough steps (root `package.json` read, then `react-toastfy/package.json`, then `scripts/postinstall.js`) — all reachable under docker.
- npm-based run (`npm run dev`) still behaves as before.

## Checklist

- [x] Documentation updated (if applicable) — N/A, walkthrough copy unchanged

### If adding a new vulnerability

- [ ] Flag added in `prisma/seed.ts` with format `OSS{...}`
- [ ] Three progressive hints added in `prisma/seed.ts`
- [ ] Vulnerable code path is exploitable and demonstrable
- [ ] Reference doc added under `content/vulnerabilities/` (concept + fix only — no exploit steps, payloads, or flag value)
- [ ] Regression tests added (unit, API, and/or E2E)
- [ ] No real-world secrets introduced
- [ ] If a walkthrough was also added under `docs/src/data/blog/`, `walkthroughSlug` is set on the flag in `prisma/seed.ts`
