### PR TITLE
docs: link Shai-Hulud to rules-file poisoning in supply-chain writeup

### DIFF
--- a/docs/src/data/blog/supply-chain-poisoned-rules-chain.md
+++ b/docs/src/data/blog/supply-chain-poisoned-rules-chain.md
@@ -266,6 +266,23 @@ The lab puts all three back to back. The bad package gets you the
 prompt-injection payload, the prompt injection turns your own agent
 against you, and the agent is what writes the actual backdoor.
 
+## Wormable supply-chain propagation
+
+Compromising one developer workstation is no longer the end goal of
+modern supply-chain attacks. It's the propagation layer.
+
+The ["Shai-Hulud" npm worm](https://unit42.paloaltonetworks.com/npm-supply-chain-attack/) (September 2025) made that explicit. Its real
+objective was stealing developer and CI credentials, especially npm tokens, and using them to publish poisoned versions
+of every package the compromised maintainer could reach.
+
+Rules-file poisoning has **not yet** been observed combined with that
+pattern, but it would fit. A poisoned Cursor/Copilot/Claude rules file
+is a persistence primitive for the developer environment: the attacker
+influences the agent that writes the code, and the directive survives
+prompts, refactors, and repositories as long as the file stays loaded.
+With CI-connected agents, the same directive can adapt to each project
+(minimal stack-specific tailoring needed).
+
 ## Defenses
 
 **Block install scripts.** `npm config set ignore-scripts true`. Opt in


### PR DESCRIPTION
## Description

Add a "Wormable supply-chain propagation" section to the rules-chain writeup, linking the lab scenario to the real-world Shai-Hulud npm worm (September 2025). Frames poisoned rules files as a persistence primitive that would fit naturally on top of a worm-style propagation layer, while being explicit that the combination has not yet been observed in the wild.

## Type of change

- [ ] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [x] Documentation update
- [ ] Other (please describe):

## Testing done

Local Astro build of `docs/`, visual check of the rendered section and the Unit 42 reference link.

## Checklist

- [x] Documentation updated (if applicable)
