### PR TITLE
feat: add first-visit onboarding guide with practice flag

### DIFF
--- a/app/api/flags/verify/route.ts
+++ b/app/api/flags/verify/route.ts
@@ -3,12 +3,19 @@ import { prisma } from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { parseBody } from "@/lib/validation";
 import { verifyFlagBodySchema } from "@/lib/validation/schemas/flags";
+import { TUTORIAL_FLAG } from "@/lib/config";
 
 export async function POST(request: Request) {
   try {
     const parsed = await parseBody(request, verifyFlagBodySchema);
     if (!parsed.success) return parsed.response;
     const { flag } = parsed.data;
+
+    // Onboarding practice flag: accepted without touching the database, so it
+    // never affects the flag count, progress, or the Hall of Fame.
+    if (flag.trim() === TUTORIAL_FLAG) {
+      return NextResponse.json({ valid: true, tutorial: true });
+    }
 
     const matchedFlag = await prisma.flag.findFirst({
       where: {

--- a/app/components/FlagChecker.tsx
+++ b/app/components/FlagChecker.tsx
@@ -25,6 +25,7 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
   const [message, setMessage] = useState<string | null>(null);
   const [foundFlags, setFoundFlags] = useState<string[]>([]);
   const [isInitialAnimation, setIsInitialAnimation] = useState(true);
+  const [highlightVerify, setHighlightVerify] = useState(false);
   const [supportBannerSlug, setSupportBannerSlug] = useState<string | null>(
     null
   );
@@ -50,6 +51,25 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
     }, INITIAL_ANIMATION_DURATION);
 
     return () => clearTimeout(timer);
+  }, []);
+
+  // The onboarding guide opens the checker and hands the player their first
+  // (practice) flag via this event so they validate it on the real control.
+  useEffect(() => {
+    const handleOpenRequest = (event: Event) => {
+      const detail = (event as CustomEvent<{ prefill?: string }>).detail;
+      setIsInitialAnimation(false);
+      setMessage(null);
+      setIsOpen(true);
+      if (detail?.prefill) {
+        setFlagInput(detail.prefill);
+        setHighlightVerify(true);
+      }
+    };
+
+    window.addEventListener("oss:open-flag-checker", handleOpenRequest);
+    return () =>
+      window.removeEventListener("oss:open-flag-checker", handleOpenRequest);
   }, []);
 
   const triggerConfetti = () => {
@@ -112,6 +132,15 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
 
       const data = await response.json();
 
+      if (data.tutorial) {
+        triggerVictoryCelebration();
+        setHighlightVerify(false);
+        setFlagInput("");
+        setIsOpen(false);
+        window.dispatchEvent(new CustomEvent("oss:tutorial-validated"));
+        return;
+      }
+
       if (data.valid) {
         if (data.alreadyFound) {
           setMessage("Flag already found!");
@@ -157,6 +186,14 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
     if (e.key === "Enter" && !isVerifying) {
       handleVerify();
     }
+  };
+
+  const closeChecker = () => {
+    if (isVerifying) return;
+    setIsOpen(false);
+    setFlagInput("");
+    setMessage(null);
+    setHighlightVerify(false);
   };
 
   return (
@@ -260,13 +297,7 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
       {isOpen && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          onClick={() => {
-            if (!isVerifying) {
-              setIsOpen(false);
-              setFlagInput("");
-              setMessage(null);
-            }
-          }}
+          onClick={closeChecker}
         >
           <div
             className="w-full max-w-md rounded-lg border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-800"
@@ -283,13 +314,7 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
                 {allFlagsFound ? "All Flags Found" : "Verify Flag"}
               </h2>
               <button
-                onClick={() => {
-                  if (!isVerifying) {
-                    setIsOpen(false);
-                    setFlagInput("");
-                    setMessage(null);
-                  }
-                }}
+                onClick={closeChecker}
                 className="cursor-pointer text-slate-400 transition-colors hover:text-slate-600 dark:hover:text-slate-300"
                 disabled={isVerifying}
               >
@@ -451,7 +476,11 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
                 <button
                   onClick={handleVerify}
                   disabled={isVerifying || !flagInput.trim()}
-                  className="rounded-lg cursor-pointer bg-primary-600 px-4 py-2 text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-primary-500 dark:hover:bg-primary-600"
+                  className={`rounded-lg cursor-pointer bg-primary-600 px-4 py-2 text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-primary-500 dark:hover:bg-primary-600 ${
+                    highlightVerify
+                      ? "ring-2 ring-primary-400 ring-offset-2"
+                      : ""
+                  }`}
                 >
                   {isVerifying ? "Verifying..." : "Verify"}
                 </button>

--- a/app/components/OnboardingGuide.tsx
+++ b/app/components/OnboardingGuide.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import Link from "next/link";
+import { DOCS_ROADMAP_URL, GITHUB_REPO, TUTORIAL_FLAG } from "@/lib/config";
+
+const STORAGE_KEY = "oss_onboarding_seen";
+const SEEN_EVENT = "oss:onboarding-seen";
+
+const CODE_CHIP =
+  "rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-primary-700 dark:bg-slate-700 dark:text-primary-300";
+
+// External store for the "already onboarded" flag. Reading via
+// useSyncExternalStore keeps SSR and the client in sync (the strip never
+// renders on the server) without setState-in-effect.
+function subscribeSeen(callback: () => void) {
+  window.addEventListener("storage", callback);
+  window.addEventListener(SEEN_EVENT, callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+    window.removeEventListener(SEEN_EVENT, callback);
+  };
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+function useFocusTrap<T extends HTMLElement>(active: boolean) {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const container = ref.current;
+    if (!container) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    container.addEventListener("keydown", handleKey);
+    return () => {
+      container.removeEventListener("keydown", handleKey);
+      previouslyFocused?.focus?.();
+    };
+  }, [active]);
+
+  return ref;
+}
+
+export default function OnboardingGuide() {
+  const [showGuide, setShowGuide] = useState(false);
+  const [showSendoff, setShowSendoff] = useState(false);
+  const guideRef = useFocusTrap<HTMLDivElement>(showGuide);
+  const sendoffRef = useFocusTrap<HTMLDivElement>(showSendoff);
+
+  const seen = useSyncExternalStore(
+    subscribeSeen,
+    () => localStorage.getItem(STORAGE_KEY) !== null,
+    () => true
+  );
+  const showStrip = !seen;
+
+  // The closing moment fires once the player validates their practice flag on
+  // the real checker (see FlagChecker's tutorial branch).
+  useEffect(() => {
+    const handleValidated = () => setShowSendoff(true);
+    window.addEventListener("oss:tutorial-validated", handleValidated);
+    return () =>
+      window.removeEventListener("oss:tutorial-validated", handleValidated);
+  }, []);
+
+  useEffect(() => {
+    if (!showGuide && !showSendoff) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setShowGuide(false);
+        setShowSendoff(false);
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [showGuide, showSendoff]);
+
+  const markSeen = () => {
+    localStorage.setItem(STORAGE_KEY, "1");
+    window.dispatchEvent(new Event(SEEN_EVENT));
+  };
+
+  const openGuide = () => {
+    markSeen();
+    setShowGuide(true);
+  };
+
+  // Hand the player their first flag and drop it straight into the real
+  // checker, pre-filled, so they only have to hit Verify.
+  const startTutorial = () => {
+    setShowGuide(false);
+    window.dispatchEvent(
+      new CustomEvent("oss:open-flag-checker", {
+        detail: { prefill: TUTORIAL_FLAG },
+      })
+    );
+  };
+
+  const renderStep = (n: number, title: string, body: React.ReactNode) => (
+    <li className="flex gap-3">
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary-100 text-sm font-bold text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">
+        {n}
+      </span>
+      <div>
+        <p className="font-semibold text-slate-900 dark:text-slate-100">
+          {title}
+        </p>
+        <p className="mt-0.5 text-sm text-slate-600 dark:text-slate-400">
+          {body}
+        </p>
+      </div>
+    </li>
+  );
+
+  const closeIcon = (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M6 18L18 6M6 6l12 12"
+      />
+    </svg>
+  );
+
+  const checkIcon = (
+    <svg
+      className="h-6 w-6"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4.5 12.75l6 6 9-13.5"
+      />
+    </svg>
+  );
+
+  return (
+    <>
+      {/* Persistent entry point, subordinate to the flag checker it sits above */}
+      <button
+        onClick={openGuide}
+        aria-label="How it works"
+        className="group fixed bottom-24 right-6 z-40 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border border-slate-200 bg-white/90 text-slate-500 shadow-md backdrop-blur-sm transition-all hover:bg-white hover:text-slate-900 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800/90 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+      >
+        <svg
+          className="h-5 w-5 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <span className="pointer-events-none absolute right-12 top-1/2 -translate-y-1/2 whitespace-nowrap rounded-lg bg-slate-900/90 px-2.5 py-1 text-xs font-medium text-white opacity-0 shadow-lg backdrop-blur-sm transition-opacity duration-200 group-hover:opacity-100 dark:bg-slate-100/90 dark:text-slate-900">
+          How it works
+        </span>
+      </button>
+
+      {/* First-visit welcome strip */}
+      {showStrip && (
+        <div
+          className="fixed right-6 top-24 z-50 w-[calc(100vw-3rem)] max-w-sm"
+          style={{ animation: "fade-in-up 0.4s ease-out" }}
+        >
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-800">
+            <div className="flex items-start gap-3">
+              <span className="text-2xl leading-none">👋</span>
+              <div className="flex-1">
+                <p className="text-sm text-slate-700 dark:text-slate-300">
+                  <span className="font-semibold text-slate-900 dark:text-slate-100">
+                    New here?
+                  </span>{" "}
+                  This isn&apos;t a real shop. It hides security flags to
+                  capture.
+                </p>
+                <div className="mt-3 flex items-center gap-2">
+                  <button
+                    onClick={openGuide}
+                    className="cursor-pointer rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600"
+                  >
+                    Take the tour →
+                  </button>
+                  <button
+                    onClick={markSeen}
+                    className="cursor-pointer rounded-lg px-3 py-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </div>
+              <button
+                onClick={markSeen}
+                aria-label="Dismiss"
+                className="cursor-pointer text-slate-400 transition-colors hover:text-slate-600 dark:hover:text-slate-300"
+              >
+                {closeIcon}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Steps modal */}
+      {showGuide && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setShowGuide(false)}
+        >
+          <div
+            ref={guideRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="How it works"
+            className="max-h-[85vh] w-full max-w-lg overflow-y-auto rounded-lg border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-800"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-5 flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+                  How it works
+                </h2>
+                <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                  This looks like a normal grocery store. It&apos;s actually a
+                  deliberately vulnerable app. Break it and capture the hidden
+                  flags.
+                </p>
+              </div>
+              <button
+                onClick={() => setShowGuide(false)}
+                aria-label="Close"
+                className="shrink-0 cursor-pointer text-slate-400 transition-colors hover:text-slate-600 dark:hover:text-slate-300"
+              >
+                {closeIcon}
+              </button>
+            </div>
+
+            <ol className="space-y-4">
+              {renderStep(
+                1,
+                "Explore & poke around",
+                "Every page may hide a vulnerability: broken auth, injections, logic flaws."
+              )}
+              {renderStep(
+                2,
+                "Capture a flag",
+                <>
+                  Exploit one and you&apos;ll uncover a flag like{" "}
+                  <code className={CODE_CHIP}>{"OSS{...}"}</code>.
+                </>
+              )}
+              {renderStep(
+                3,
+                "Validate it",
+                <>
+                  Here&apos;s your first one:{" "}
+                  <code className={CODE_CHIP}>{TUTORIAL_FLAG}</code>. Hit the
+                  button below and we&apos;ll load it straight into the checker.
+                </>
+              )}
+              {renderStep(
+                4,
+                "Follow the roadmap",
+                <>
+                  New to AppSec? The{" "}
+                  <a
+                    href={DOCS_ROADMAP_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-primary-600 hover:underline dark:text-primary-400"
+                  >
+                    roadmap
+                  </a>{" "}
+                  orders challenges from easy to hard.
+                </>
+              )}
+            </ol>
+
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-4 text-sm">
+                <Link
+                  href="/flags"
+                  onClick={() => setShowGuide(false)}
+                  className="font-medium text-primary-600 hover:underline dark:text-primary-400"
+                >
+                  Browse challenges
+                </Link>
+              </div>
+              <button
+                onClick={startTutorial}
+                autoFocus
+                className="cursor-pointer rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:bg-primary-500 dark:hover:bg-primary-600"
+              >
+                Validate my first flag →
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Closing send-off */}
+      {showSendoff && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setShowSendoff(false)}
+        >
+          <div
+            ref={sendoffRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="You're all set"
+            className="w-full max-w-md rounded-lg border border-slate-200 bg-white p-6 text-center shadow-xl dark:border-slate-700 dark:bg-slate-800"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900/40 dark:text-primary-400">
+              {checkIcon}
+            </div>
+            <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+              You&apos;re all set
+            </h2>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+              Practice flag captured. That&apos;s the exact loop. Real flags are
+              hidden across the store, so go break things. Good luck!
+            </p>
+            <p className="mt-4 text-sm text-slate-600 dark:text-slate-400">
+              Enjoying OSS? A ⭐ on GitHub keeps it growing.
+            </p>
+            <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-center">
+              <a
+                href={GITHUB_REPO}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+              >
+                Star on GitHub
+              </a>
+              <button
+                onClick={() => setShowSendoff(false)}
+                autoFocus
+                className="cursor-pointer rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+              >
+                Start hacking
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import FlagCheckerWrapper from "./components/FlagCheckerWrapper";
 import HintPanelWrapper from "./components/HintPanelWrapper";
 import ConsoleWelcome from "./components/ConsoleWelcome";
 import VisitorTracker from "./components/VisitorTracker";
+import OnboardingGuide from "./components/OnboardingGuide";
 
 const poppins = Poppins({
   weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
@@ -31,6 +32,7 @@ export default function RootLayout({
         <HintPanelWrapper />
         <ConsoleWelcome />
         <VisitorTracker />
+        <OnboardingGuide />
       </body>
     </html>
   );

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,3 +5,13 @@ export function getBaseUrl(): string {
 const DOCS_SITE_URL = "https://koadt.github.io/oss-oopssec-store";
 export const DOCS_BASE_URL = `${DOCS_SITE_URL}/posts`;
 export const DOCS_ROADMAP_URL = `${DOCS_SITE_URL}/roadmap`;
+
+export const GITHUB_REPO = "https://github.com/kOaDT/oss-oopssec-store";
+
+/**
+ * Tutorial-only flag used by the onboarding guide. It is intentionally NOT
+ * stored in the database, so it never counts toward the real flag total,
+ * the player's progress, or the Hall of Fame. The verify route short-circuits
+ * on this exact value and returns `{ valid: true, tutorial: true }`.
+ */
+export const TUTORIAL_FLAG = "OSS{0ops_i_h4ck3d_1t}";

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3553,7 +3552,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3563,7 +3561,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3685,7 +3682,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -4226,7 +4222,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4990,7 +4985,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6259,7 +6253,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -6554,7 +6547,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6655,7 +6647,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6757,7 +6748,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9038,7 +9028,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -12813,7 +12802,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13053,7 +13041,6 @@
       "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13124,7 +13111,6 @@
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -13353,7 +13339,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13363,7 +13348,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14745,8 +14729,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -15109,7 +15092,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15346,7 +15328,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16092,7 +16073,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/tests/api/onboarding-tutorial-flag.test.ts
+++ b/tests/api/onboarding-tutorial-flag.test.ts
@@ -1,0 +1,59 @@
+import { apiRequest } from "../helpers/api";
+import { TUTORIAL_FLAG } from "@/lib/config";
+
+interface VerifyResponse {
+  valid: boolean;
+  tutorial?: boolean;
+  slug?: string;
+  alreadyFound?: boolean;
+  foundAt?: string;
+}
+
+interface ProgressResponse {
+  foundFlags: { slug: string }[];
+}
+
+describe("Onboarding practice flag", () => {
+  it("POST /api/flags/verify accepts the tutorial flag with { valid: true, tutorial: true }", async () => {
+    const { status, data } = await apiRequest<VerifyResponse>(
+      "/api/flags/verify",
+      {
+        method: "POST",
+        body: JSON.stringify({ flag: TUTORIAL_FLAG }),
+      }
+    );
+
+    expect(status).toBe(200);
+    expect(data).toHaveProperty("valid", true);
+    expect(data).toHaveProperty("tutorial", true);
+  });
+
+  it("short-circuits before the database, so it carries no real-flag fields", async () => {
+    const { data } = await apiRequest<VerifyResponse>("/api/flags/verify", {
+      method: "POST",
+      body: JSON.stringify({ flag: TUTORIAL_FLAG }),
+    });
+
+    // Real flags return slug/alreadyFound/foundAt; the tutorial short-circuit must not.
+    expect(data).not.toHaveProperty("slug");
+    expect(data).not.toHaveProperty("alreadyFound");
+    expect(data).not.toHaveProperty("foundAt");
+  });
+
+  it("never reaches the Hall of Fame, even when submitted repeatedly", async () => {
+    const before = await apiRequest<ProgressResponse>("/api/flags/progress");
+    const countBefore = before.data.foundFlags.length;
+
+    await apiRequest("/api/flags/verify", {
+      method: "POST",
+      body: JSON.stringify({ flag: TUTORIAL_FLAG }),
+    });
+    await apiRequest("/api/flags/verify", {
+      method: "POST",
+      body: JSON.stringify({ flag: ` ${TUTORIAL_FLAG} ` }),
+    });
+
+    const after = await apiRequest<ProgressResponse>("/api/flags/progress");
+    expect(after.data.foundFlags.length).toBe(countBefore);
+  });
+});


### PR DESCRIPTION
## Description

Adds a first-load onboarding experience so newcomers understand the site is a deliberately vulnerable CTF playground, not a real shop.

- **Welcome flash** (top-right, first visit only): a dismissible card that stays until the user dismisses it or starts the tour. State is read via `useSyncExternalStore` so it never renders on the server (no hydration mismatch).
- **"How it works" steps modal**: explains the loop (explore → capture → validate → roadmap), with the roadmap link inline in step 4.
- **Guided validation**: the modal hands the player a practice flag and opens the *real* FlagChecker pre-filled, so they validate it on the actual control. A closing send-off wishes them luck and asks for a GitHub star.
- **Persistent "?" entry point** above the flag checker to reopen the guide anytime.

The practice flag is accepted by the verify route **without touching the database**, so it never affects the flag count, progress, or the Hall of Fame. Components communicate via `CustomEvent` (`oss:open-flag-checker`, `oss:tutorial-validated`).

## Type of change

- [ ] Bug fix
- [x] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [ ] Documentation update
- [ ] Other (please describe):

## Testing done

- `npx tsc --noEmit` — clean
- `npx eslint` — clean
- Manual flow: first load shows the flash top-right → *Take the tour* opens the steps modal → *Validate my first flag* opens the FlagChecker pre-filled with Verify highlighted → *Verify* triggers confetti and the send-off → the *?* button reopens the guide → dismissing persists across reloads (localStorage). Verified the practice flag does **not** change the `X/Y` count or progress.

## Checklist

- [x] Documentation updated (if applicable) — N/A, UI-only feature

### If adding a new vulnerability

- [ ] Flag added in `prisma/seed.ts` with format `OSS{...}`
- [ ] Three progressive hints added in `prisma/seed.ts`
- [ ] Vulnerable code path is exploitable and demonstrable
- [ ] Reference doc added under `content/vulnerabilities/` (concept + fix only — no exploit steps, payloads, or flag value)
- [ ] Regression tests added (unit, API, and/or E2E)
- [ ] No real-world secrets introduced
- [ ] If a walkthrough was also added under `docs/src/data/blog/`, `walkthroughSlug` is set on the flag in `prisma/seed.ts`
