### PR TITLE
Feat/comparison table and star reminder

### DIFF
--- a/EDUCATORS.md
+++ b/EDUCATORS.md
@@ -22,7 +22,7 @@ Point your students to the [Roadmap](https://koadt.github.io/oss-oopssec-store/r
 
 ## Table of Contents
 
-1. [Why OopsSec Store?](#why-oss-oopssec-store)
+1. [Why OopsSec Store?](#why-oopssec-store)
 2. [OWASP Coverage Grid](#owasp-coverage-grid)
 3. [Challenge Catalog & Time Estimates](#challenge-catalog--time-estimates)
 4. [Syllabus Integration Guide](#syllabus-integration-guide)
@@ -34,18 +34,9 @@ Point your students to the [Roadmap](https://koadt.github.io/oss-oopssec-store/r
 
 ## Why OopsSec Store?
 
-OopsSec Store is the only intentionally vulnerable web application built with **Next.js and React**: the stack your students will actually encounter in production.
+OopsSec Store is the only intentionally vulnerable web application built with **Next.js and React**: the stack your students will actually encounter in production. It also treats the AI-era attack surface — prompt injection, MCP tool poisoning, AI coding-agent backdoors, supply-chain attack chains — as first-class challenges, not add-ons.
 
-|                           | OopsSec Store                    | DVWA            | Juice Shop        |
-| ------------------------- | -------------------------------- | --------------- | ----------------- |
-| Stack                     | Next.js · React · Prisma         | PHP · MySQL     | Node.js · Angular |
-| Setup                     | `npx create-oss-store` (< 1 min) | Manual / Docker | Docker            |
-| CTF format with flags     | ✅                               | ❌              | ✅                |
-| Walkthroughs included     | ✅                               | Partial (hints) | ❌                |
-| Modern API attack vectors | ✅                               | ❌              | Partial           |
-| Actively maintained       | ✅                               | ⚠️              | ✅                |
-| Hall of Fame for students | ✅                               | ❌              | ❌                |
-| Free & open source (MIT)  | ✅                               | ✅              | ✅                |
+For a feature-by-feature comparison with Juice Shop and DVWA, see the [comparison table in the README](https://github.com/kOaDT/oss-oopssec-store#why-oopssec-store).
 
 Each vulnerability hides a flag in the format `OSS{...}`. Walkthroughs are available at [koadt.github.io/oss-oopssec-store](https://koadt.github.io/oss-oopssec-store) (useful for debriefing sessions or when students get stuck.)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ docker run -p 3000:3000 leogra/oss-oopssec-store
 ## Table of contents
 
 - [Features](#features)
+- [Why OopsSec Store?](#why-oopssec-store)
 - [Installation](#installation)
   - [Quick start (npm)](#quick-start)
   - [Docker](#docker)
@@ -78,6 +79,26 @@ docker run -p 3000:3000 leogra/oss-oopssec-store
 - 34 CTF challenges across 11 chapters, laid out as a structured [learning roadmap](https://koadt.github.io/oss-oopssec-store/roadmap)
 - Vulnerability documentation and community walkthroughs for each challenge
 - Automated tests that verify exploits still work (PRs that accidentally fix a vuln will fail CI)
+
+## Why OopsSec Store?
+
+OopsSec Store is the only intentionally vulnerable web application built with **Next.js and React**. The stack you'll actually encounter in production. And the AI-era attack surface is part of the core curriculum, not an afterthought: prompt injection, MCP tool poisoning, AI coding-agent backdoors, and an npm supply-chain attack chain simulated end to end.
+
+|                                                | OopsSec Store                                           | Juice Shop                              | DVWA                      |
+| ---------------------------------------------- | ------------------------------------------------------- | --------------------------------------- | ------------------------- |
+| Stack                                          | Next.js · React · Prisma                                | Node.js · Express · Angular             | PHP · MySQL               |
+| Setup                                          | `npx create-oss-store` (< 1 min) / Docker               | Docker / npm                            | Docker / manual LAMP      |
+| CTF flags                                      | ✅ Built in                                             | ✅ Opt-in CTF mode                      | ❌                        |
+| Guided learning roadmap                        | ✅ 1 roadmap, 11 chapters, 34 flags                     | ❌ Score board only                     | Partial (security levels) |
+| Walkthrough for every challenge                | ✅                                                      | ✅ Companion guide                      | Partial (hints)           |
+| LLM prompt injection                           | ✅ Plug in a free API key                               | ✅ v20+, bring & configure your own LLM | ❌                        |
+| MCP tool poisoning                             | ✅                                                      | ❌                                      | ❌                        |
+| AI coding-agent backdoor (poisoned rules file) | ✅                                                      | ❌                                      | ❌                        |
+| Supply-chain attack chain                      | ✅ Simulated end to end: npm typosquat → rules backdoor | Partial — identification only           | ❌                        |
+| Challenges built on real CVEs                  | ✅                                                      | ❌                                      | ❌                        |
+| Hall of Fame for players                       | ✅                                                      | ❌                                      | ❌                        |
+
+<sub>Last verified June 2026, against Juice Shop v20 and DVWA 2.x. Spotted an inaccuracy? [Open an issue](https://github.com/kOaDT/oss-oopssec-store/issues) or [open a PR](https://github.com/kOaDT/oss-oopssec-store/pulls).</sub>
 
 ## Installation
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,4 +10,9 @@ if [ ! -f "$DB_FILE" ]; then
   echo "Database initialized successfully."
 fi
 
+echo ""
+echo "★ Enjoying the lab? A star helps others find it:"
+echo "  https://github.com/kOaDT/oss-oopssec-store"
+echo ""
+
 exec npm start

--- a/packages/create-oss-store/src/index.js
+++ b/packages/create-oss-store/src/index.js
@@ -130,6 +130,10 @@ export async function createOssStore(projectName) {
   console.log();
   console.log(chalk.dim("Good luck finding all the flags!"));
   console.log();
+  console.log(
+    `${chalk.yellow("★")} Enjoying the lab? A star helps others find it: ${chalk.underline("https://github.com/kOaDT/oss-oopssec-store")}`
+  );
+  console.log();
 }
 
 function runCommand(command, args, cwd) {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,6 +44,11 @@ npm run build
 
 echo "Setup completed successfully!"
 
+echo ""
+echo "★ Enjoying the lab? A star helps others find it:"
+echo "  https://github.com/kOaDT/oss-oopssec-store"
+echo ""
+
 echo "Launching Prisma Studio and application..."
 npx prisma studio -b none &
 PRISMA_PID=$!


### PR DESCRIPTION
## Description

**1. Comparison table moved to the README ("Why OopsSec Store?" section)**

The comparison table previously lived in EDUCATORS.md and contained several factual errors. It now sits in the README right after Features, fully fact-checked (June 2026, against Juice Shop v20 and DVWA 2.x):

- Juice Shop *does* ship official walkthroughs (companion guide with full solutions) — fixed.
- DVWA *is* actively maintained — the row no longer differentiated anyone and was removed.
- Juice Shop v20 (May 2026) added LLM prompt injection challenges — acknowledged honestly, with the real nuance: they require a self-configured LLM, ours works with a free API key.
- New rows for the modern attack surface where OopsSec Store stands alone: MCP tool poisoning, AI coding-agent backdoor (poisoned rules file), end-to-end simulated supply-chain attack chain, challenges built on real CVEs.
- A "last verified" footnote invites issues/PRs if anything is inaccurate.

EDUCATORS.md now links to the README table instead of duplicating it (its broken TOC anchor was fixed along the way).

**2. GitHub star reminder on install**

A short, consistent star reminder is now printed by all three install paths:

- `npx create-oss-store` (end of the success message)
- `npm run setup` (after "Setup completed successfully!")
- Docker entrypoint (on container start, before `npm start`)

Note: the `create-oss-store` change requires a version bump + npm publish to reach users.

## Type of change

- [ ] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [x] Documentation update
- [x] Other (please describe): CLI/install UX (star reminder)

## Testing done

- `bash -n scripts/setup.sh`, `sh -n docker-entrypoint.sh` and `node --check packages/create-oss-store/src/index.js` all pass.
- Every claim in the comparison table was verified against primary sources (Juice Shop v20 release notes, Pwning OWASP Juice Shop companion guide, DVWA repo activity) in June 2026.
- Markdown rendering of the new README section checked locally.

## Checklist

- [x] Documentation updated (if applicable)
