### PR TITLE
Fix/padding oracle writeup oracle accuracy

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,6 @@
 import Header from "../components/Header";
 import Footer from "../components/Footer";
+import { DOCS_ROADMAP_URL } from "@/lib/config";
 
 export default function About() {
   return (
@@ -81,47 +82,102 @@ export default function About() {
               </div>
               <div className="space-y-4 text-slate-700 dark:text-slate-300">
                 <p className="leading-relaxed">
-                  This platform is designed to help you learn about common web
-                  security vulnerabilities and how to identify, exploit, and
-                  ultimately defend against them. Key areas of focus include:
+                  This platform is designed to help you learn how to identify,
+                  exploit, and ultimately defend against real-world security
+                  vulnerabilities — from classic web flaws to AI-, crypto-, and
+                  supply-chain-specific risks. The challenges are grouped into
+                  these areas:
                 </p>
                 <div className="grid gap-4 md:grid-cols-2">
                   <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
                     <h3 className="mb-2 font-semibold text-slate-900 dark:text-slate-100">
-                      Injection Attacks
+                      Injection
                     </h3>
                     <p className="text-sm text-slate-600 dark:text-slate-400">
-                      SQL injection, command injection, and other injection
-                      vulnerabilities
+                      SQL injection (search, second-order, header-based),
+                      cross-site scripting (XSS), XXE, and prompt injection
+                      against the AI assistant
                     </p>
                   </div>
                   <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
                     <h3 className="mb-2 font-semibold text-slate-900 dark:text-slate-100">
-                      Authentication & Session
+                      Authentication
                     </h3>
                     <p className="text-sm text-slate-600 dark:text-slate-400">
-                      Broken authentication, session management flaws, and
-                      access control issues
+                      Brute force without rate limiting, weak JWT secrets,
+                      session fixation, and insecure password resets
                     </p>
                   </div>
                   <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
                     <h3 className="mb-2 font-semibold text-slate-900 dark:text-slate-100">
-                      Cross-Site Scripting
+                      Authorization
                     </h3>
                     <p className="text-sm text-slate-600 dark:text-slate-400">
-                      XSS vulnerabilities and client-side security concerns
+                      Insecure direct object references (IDOR), broken
+                      object-level authorization, and middleware access-control
+                      bypasses
                     </p>
                   </div>
                   <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
                     <h3 className="mb-2 font-semibold text-slate-900 dark:text-slate-100">
-                      Security Misconfiguration
+                      Request Forgery
                     </h3>
                     <p className="text-sm text-slate-600 dark:text-slate-400">
-                      Improper security settings and exposed sensitive
-                      information
+                      Cross-site request forgery (CSRF), including
+                      profile-takeover chains, and server-side request forgery
+                      (SSRF)
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
+                    <h3 className="mb-2 font-semibold text-slate-900 dark:text-slate-100">
+                      Cryptographic Failures
+                    </h3>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      Weak MD5 hashing, an AES-CBC padding oracle, and insecure
+                      randomness
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
+                    <h3 className="mb-2 font-semibold text-slate-900 dark:text-slate-100">
+                      Information Disclosure
+                    </h3>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      Verbose API errors, plaintext passwords in logs, and
+                      secrets leaked through public environment variables
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
+                    <h3 className="mb-2 font-semibold text-slate-900 dark:text-slate-100">
+                      Input Validation
+                    </h3>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      Client-side price manipulation, mass assignment, open
+                      redirects, and path traversal
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
+                    <h3 className="mb-2 font-semibold text-slate-900 dark:text-slate-100">
+                      Supply Chain & Insecure Design
+                    </h3>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">
+                      npm typosquatting, a malicious AI rules-file backdoor,
+                      business-logic flaws, and remote code execution
                     </p>
                   </div>
                 </div>
+                <p className="leading-relaxed">
+                  Not sure where to start? The{" "}
+                  <a
+                    href={DOCS_ROADMAP_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-primary-600 underline-offset-2 hover:underline dark:text-primary-400"
+                  >
+                    guided roadmap
+                  </a>{" "}
+                  orders these challenges into a recommended learning path, from
+                  reconnaissance basics through to chained, real-world exploits.
+                </p>
               </div>
             </div>
 

--- a/docs/src/data/blog/aes-cbc-padding-oracle-forged-share-token.md
+++ b/docs/src/data/blog/aes-cbc-padding-oracle-forged-share-token.md
@@ -88,19 +88,21 @@ Decryption failed. Bad padding.
 
 ### Flipping a byte in the IV
 
-Now modify a hex character in the first 32 characters (the IV):
+For a single block the IV is the previous block: each IV byte XORs into exactly one plaintext byte. To keep valid padding while still corrupting the content, flip a byte that lands inside the resource id (`ORD-004`), not the `order` type name and not the last byte (which carries the padding). Here we change a byte in the middle of the IV:
 
 ```bash
-# Change the first hex digit
-MODIFIED="0${TOKEN:1}"
+# Change a hex digit mapping to the resource id (leaves "order:" and the padding intact)
+MODIFIED="${TOKEN:0:12}0${TOKEN:13}"
 curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/share?token=$MODIFIED"
 ```
 
 Response: **404** — `{"error": "Shared resource not found"}`
 
-Changing the IV doesn't break padding (padding depends on the ciphertext block), but it corrupts the decrypted plaintext. So the server got valid padding, tried to look up the garbled resource path, found nothing, and returned 404.
+The padding byte is untouched, so decryption succeeds, but the plaintext now reads `order:<garbage>`. The server parsed a valid type, looked up a resource that doesn't exist, and returned 404.
 
-There's our oracle: **400 = bad padding, 404 = valid padding**.
+Two traps to avoid when probing: flipping the _last_ IV byte corrupts the padding itself → 400, and flipping a byte in the `order` type name makes the type unknown → 400 `Unsupported resource type`. Only a byte inside the id gives a clean 404.
+
+There's our oracle: a **400** means the padding was rejected, while any **non-400** response (404 here) means the padding was valid and the server simply couldn't route the plaintext. The attack needs exactly that one bit.
 
 ## Understanding the vulnerability
 
@@ -158,6 +160,8 @@ When attacking the last byte, a guess might produce valid padding like `\x02\x02
 2. If the server now returns 400, the original result was a false positive (the padding was `\x02\x02`, not `\x01`)
 3. Skip this guess and move on
 
+One more subtlety: the 400-vs-non-400 signal isn't perfectly clean. A decryption that produces valid padding but whose plaintext happens to contain a `:` followed by an unknown type also returns 400 (`Unsupported resource type`). Since `intermediate = plaintext XOR IV` is effectively random per token, there's roughly a 6% chance (`1 - (255/256)^16`) that the block's intermediate value contains a `:` (`0x3a`), in which case the highest byte can't be recovered and the script bails out. If that happens, just generate a fresh share token and run it again.
+
 ## Exploitation
 
 ### Step 1: Generate a valid share token
@@ -178,8 +182,8 @@ curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/shar
 FLIP_CT="${TOKEN:0:63}$(printf '%x' $(( (0x${TOKEN:63:1} + 1) % 16 )))"
 curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/share?token=$FLIP_CT"
 
-# Flip first IV byte — should return 404 (valid padding, wrong resource)
-FLIP_IV="$(printf '%x' $(( (0x${TOKEN:0:1} + 1) % 16 )))${TOKEN:1}"
+# Flip a byte inside the resource id — should return 404 (valid padding, wrong resource)
+FLIP_IV="${TOKEN:0:12}$(printf '%x' $(( (0x${TOKEN:12:1} + 1) % 16 )))${TOKEN:13}"
 curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000/api/documents/share?token=$FLIP_IV"
 ```
 
@@ -245,7 +249,6 @@ def recover_intermediate(cipher_block: bytes) -> bytearray:
                         continue
 
                 intermediate[byte_pos] = guess ^ padding_value
-                plaintext_byte = intermediate[byte_pos] ^ 0  # XOR with 0 (test IV)
                 print(
                     f"  [+] Byte {byte_pos:2d}: "
                     f"intermediate=0x{intermediate[byte_pos]:02x} "


### PR DESCRIPTION
## Description

Two documentation/content updates:

- **Padding oracle writeup** (`docs/.../aes-cbc-padding-oracle-forged-share-token.md`): corrects the writeup to match the challenge's actual behavior. The IV byte-flip example now targets a byte inside the resource id (instead of the first/last byte) so padding stays valid, documents the two traps that produce false 400s (flipping the padding byte, or hitting the `order` type name), reframes the oracle as *400 = bad padding / non-400 = valid padding*, and notes the ~6% chance a `:` in the intermediate value forces a retry with a fresh token.
- **About page** (`app/about/page.tsx`): reworks the "Learning Objectives" section, which was stale (only 4 categories, two of which — "Cross-Site Scripting", "Security Misconfiguration" — didn't match the lab's taxonomy). It now reflects the real categories from `prisma/seed.ts` / `FlagCategory` (Injection, Authentication, Authorization, Request Forgery, Cryptographic Failures, Information Disclosure, Input Validation, Supply Chain & Insecure Design) with examples drawn from actual challenges, and adds a link to the guided roadmap.

## Type of change

- [ ] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [x] Documentation update
- [ ] Other (please describe):

## Testing done

- Padding oracle: re-followed the writeup steps against the running challenge — the middle-IV-byte flip returns 404, the documented traps return 400, and the corrected exploit script recovers the token.
- About page: verified the page renders and the roadmap link points to https://koadt.github.io/oss-oopssec-store/roadmap/. No logic changes.

## Checklist

- [x] Documentation updated (if applicable)

### If adding a new vulnerability

- [ ] Flag added in `prisma/seed.ts` with format `OSS{...}`
- [ ] Three progressive hints added in `prisma/seed.ts`
- [ ] Vulnerable code path is exploitable and demonstrable
- [ ] Reference doc added under `content/vulnerabilities/` (concept + fix only — no exploit steps, payloads, or flag value)
- [ ] Regression tests added (unit, API, and/or E2E)
- [ ] No real-world secrets introduced
- [ ] If a walkthrough was also added under `docs/src/data/blog/`, `walkthroughSlug` is set on the flag in `prisma/seed.ts`
