### PR TITLE
feat: add contributors section to Hall of Fame

### DIFF
--- a/app/components/FlagChecker.tsx
+++ b/app/components/FlagChecker.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import confetti from "canvas-confetti";
 import SupportBanner, { shouldShowSupportBanner } from "./SupportBanner";
+import { GITHUB_REPO } from "@/lib/config";
 
 function formatSlugToTitle(slug: string): string {
   return slug
@@ -436,7 +437,7 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
                       Request on GitHub.
                     </p>
                     <a
-                      href="https://github.com/kOaDT/oss-oopssec-store/blob/main/hall-of-fame/data.json"
+                      href={`${GITHUB_REPO}/blob/main/hall-of-fame/data.json`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-2 rounded-lg bg-yellow-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-yellow-700 dark:bg-yellow-500 dark:hover:bg-yellow-600"

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,8 +1,7 @@
 import Link from "next/link";
 import packageJson from "../../package.json";
-import { DOCS_ROADMAP_URL } from "@/lib/config";
+import { DOCS_ROADMAP_URL, GITHUB_REPO } from "@/lib/config";
 
-const GITHUB_REPO = "https://github.com/kOaDT/oss-oopssec-store";
 const GITHUB_ISSUES = `${GITHUB_REPO}/issues`;
 const GITHUB_DISCUSSIONS = `${GITHUB_REPO}/discussions`;
 const DEV_TO_URL = "https://dev.to/oopssec-store";

--- a/app/components/SupportBanner.tsx
+++ b/app/components/SupportBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { GITHUB_REPO } from "@/lib/config";
 
 const STORAGE_KEY = "oss_support_dismissed";
 const FLAG_BANNER_PREFIX = "oss_support_shown_";
@@ -95,7 +96,7 @@ export default function SupportBanner({
 
         <div className="mb-3 flex flex-wrap items-center gap-2">
           <a
-            href="https://github.com/kOaDT/oss-oopssec-store"
+            href={GITHUB_REPO}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
@@ -118,7 +119,7 @@ export default function SupportBanner({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
             <a
-              href="https://github.com/kOaDT/oss-oopssec-store/fork"
+              href={`${GITHUB_REPO}/fork`}
               target="_blank"
               rel="noopener noreferrer"
               className="transition-colors hover:text-slate-700 dark:hover:text-slate-300"
@@ -127,7 +128,7 @@ export default function SupportBanner({
             </a>
             <span className="text-slate-300 dark:text-slate-600">|</span>
             <a
-              href="https://github.com/kOaDT/oss-oopssec-store/blob/main/hall-of-fame/data.json"
+              href={`${GITHUB_REPO}/blob/main/hall-of-fame/data.json`}
               target="_blank"
               rel="noopener noreferrer"
               className="transition-colors hover:text-slate-700 dark:hover:text-slate-300"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,7 @@
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import Link from "next/link";
+import { GITHUB_REPO } from "@/lib/config";
 
 export default function Contact() {
   return (
@@ -53,7 +54,7 @@ export default function Contact() {
 
             <div className="grid gap-6 md:grid-cols-3">
               <Link
-                href="https://github.com/kOaDT/oss-oopssec-store"
+                href={GITHUB_REPO}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="group rounded-2xl border border-slate-200 bg-white p-6 transition-all hover:border-primary-300 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:hover:border-primary-600"
@@ -97,7 +98,7 @@ export default function Contact() {
               </Link>
 
               <Link
-                href="https://github.com/kOaDT/oss-oopssec-store/discussions"
+                href={`${GITHUB_REPO}/discussions`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="group rounded-2xl border border-slate-200 bg-white p-6 transition-all hover:border-primary-300 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:hover:border-primary-600"
@@ -143,7 +144,7 @@ export default function Contact() {
               </Link>
 
               <Link
-                href="https://github.com/kOaDT/oss-oopssec-store/issues"
+                href={`${GITHUB_REPO}/issues`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="group rounded-2xl border border-slate-200 bg-white p-6 transition-all hover:border-primary-300 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:hover:border-primary-600"

--- a/app/hall-of-fame/ContributorsSection.tsx
+++ b/app/hall-of-fame/ContributorsSection.tsx
@@ -1,0 +1,75 @@
+import Image from "next/image";
+import type { Contributor } from "@/lib/types";
+import { CodeIcon, GitHubIcon } from "./icons";
+
+interface ContributorsSectionProps {
+  contributors: Contributor[];
+}
+
+export default function ContributorsSection({
+  contributors,
+}: ContributorsSectionProps) {
+  if (contributors.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="container mx-auto px-4 pb-16 md:pb-20">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-12 text-center">
+          <div
+            className="mb-6 inline-flex items-center justify-center bg-primary-100 p-4 dark:bg-primary-900/30"
+            style={{ borderRadius: "8px" }}
+          >
+            <CodeIcon className="h-8 w-8 text-primary-600 dark:text-primary-400" />
+          </div>
+          <h2 className="mb-3 text-4xl font-light tracking-tight text-slate-900 dark:text-slate-100 md:text-5xl">
+            Contributors
+          </h2>
+          <p className="mx-auto max-w-2xl text-lg text-slate-600 dark:text-slate-400">
+            The people building and improving OopsSec Store.
+          </p>
+        </div>
+
+        <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+          {contributors.map((contributor) => (
+            <li key={contributor.username}>
+              <a
+                href={contributor.githubUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex h-full flex-col items-center gap-3 bg-white p-6 shadow-md transition-all duration-300 hover:shadow-2xl dark:bg-slate-800"
+                style={{ borderRadius: "8px" }}
+              >
+                <div className="relative">
+                  <Image
+                    src={contributor.avatarUrl}
+                    alt={`${contributor.username}'s avatar`}
+                    width={72}
+                    height={72}
+                    className="h-[72px] w-[72px] rounded-full border-2 border-white object-cover shadow-md dark:border-slate-700"
+                  />
+                  <span
+                    className="absolute -bottom-1 -right-1 flex h-7 w-7 items-center justify-center bg-slate-900 text-white shadow-md transition-colors group-hover:bg-primary-600 dark:bg-slate-700"
+                    style={{ borderRadius: "50%" }}
+                  >
+                    <GitHubIcon className="h-4 w-4" />
+                  </span>
+                </div>
+                <span className="text-center text-sm font-medium text-slate-900 dark:text-slate-100">
+                  {contributor.username}
+                </span>
+                <span className="text-xs text-slate-500 dark:text-slate-500">
+                  {contributor.contributions}{" "}
+                  {contributor.contributions === 1
+                    ? "contribution"
+                    : "contributions"}
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/app/hall-of-fame/HallOfFameClient.tsx
+++ b/app/hall-of-fame/HallOfFameClient.tsx
@@ -4,42 +4,7 @@ import { useState, useMemo } from "react";
 import Image from "next/image";
 import type { HallOfFameEntry } from "@/lib/types";
 import { getCountryFlag } from "@/app/hall-of-fame/constants";
-
-function TrophyIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M5 3h14a2 2 0 012 2v2a4 4 0 01-4 4h-1v2a4 4 0 01-4 4 4 4 0 01-4-4v-2H7a4 4 0 01-4-4V5a2 2 0 012-2zm7 14v4m-4 0h8"
-      />
-    </svg>
-  );
-}
-
-function GitHubIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        fillRule="evenodd"
-        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-}
+import { TrophyIcon, GitHubIcon } from "./icons";
 
 function formatDate(dateString: string): string {
   try {

--- a/app/hall-of-fame/icons.tsx
+++ b/app/hall-of-fame/icons.tsx
@@ -1,0 +1,58 @@
+interface IconProps {
+  className?: string;
+}
+
+export function TrophyIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M5 3h14a2 2 0 012 2v2a4 4 0 01-4 4h-1v2a4 4 0 01-4 4 4 4 0 01-4-4v-2H7a4 4 0 01-4-4V5a2 2 0 012-2zm7 14v4m-4 0h8"
+      />
+    </svg>
+  );
+}
+
+export function GitHubIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export function CodeIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"
+      />
+    </svg>
+  );
+}

--- a/app/hall-of-fame/page.tsx
+++ b/app/hall-of-fame/page.tsx
@@ -3,8 +3,14 @@ import Footer from "../components/Footer";
 import type { HallOfFameEntry } from "@/lib/types";
 import hallOfFameData from "@/hall-of-fame/data.json";
 import HallOfFameClient from "./HallOfFameClient";
+import ContributorsSection from "./ContributorsSection";
+import { TrophyIcon, GitHubIcon } from "./icons";
+import { fetchContributors } from "@/lib/github";
+import { GITHUB_REPO } from "@/lib/config";
 
-const GITHUB_REPO = "https://github.com/kOaDT/oss-oopssec-store";
+// Next.js requires a statically-analyzable literal here; keep in sync with
+// CONTRIBUTORS_REVALIDATE_SECONDS in lib/config.ts (24h).
+export const revalidate = 86400;
 
 export const metadata = {
   title: "Hall of Fame – OopsSec Store",
@@ -12,44 +18,9 @@ export const metadata = {
     "Players who have discovered all security flags in OopsSec Store",
 };
 
-function TrophyIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M5 3h14a2 2 0 012 2v2a4 4 0 01-4 4h-1v2a4 4 0 01-4 4 4 4 0 01-4-4v-2H7a4 4 0 01-4-4V5a2 2 0 012-2zm7 14v4m-4 0h8"
-      />
-    </svg>
-  );
-}
-
-function GitHubIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        fillRule="evenodd"
-        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-}
-
-export default function HallOfFame() {
+export default async function HallOfFame() {
   const entries = hallOfFameData as HallOfFameEntry[];
+  const contributors = await fetchContributors();
 
   return (
     <div className="flex min-h-screen flex-col bg-slate-50 dark:bg-slate-900">
@@ -142,6 +113,8 @@ export default function HallOfFame() {
             </div>
           </div>
         </section>
+
+        <ContributorsSection contributors={contributors} />
       </main>
       <Footer />
     </div>

--- a/app/player-dashboard/PlayerDashboardClient.tsx
+++ b/app/player-dashboard/PlayerDashboardClient.tsx
@@ -2,10 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { DOCS_BASE_URL } from "@/lib/config";
+import { DOCS_BASE_URL, GITHUB_REPO } from "@/lib/config";
 import { getCveUrl, getCweUrl, getOwaspUrl } from "@/lib/format";
-
-const GITHUB_REPO = "https://github.com/kOaDT/oss-oopssec-store";
 
 interface FoundFlag {
   slug: string;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -6,7 +6,11 @@ const DOCS_SITE_URL = "https://koadt.github.io/oss-oopssec-store";
 export const DOCS_BASE_URL = `${DOCS_SITE_URL}/posts`;
 export const DOCS_ROADMAP_URL = `${DOCS_SITE_URL}/roadmap`;
 
-export const GITHUB_REPO = "https://github.com/kOaDT/oss-oopssec-store";
+export const GITHUB_REPO_SLUG = "kOaDT/oss-oopssec-store";
+export const GITHUB_REPO = `https://github.com/${GITHUB_REPO_SLUG}`;
+
+/** Cache TTL (in seconds) for the GitHub-backed contributors list. */
+export const CONTRIBUTORS_REVALIDATE_SECONDS = 86_400;
 
 /**
  * Tutorial-only flag used by the onboarding guide. It is intentionally NOT

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,42 @@
+import type { Contributor } from "@/lib/types";
+import {
+  GITHUB_REPO_SLUG,
+  CONTRIBUTORS_REVALIDATE_SECONDS,
+} from "@/lib/config";
+
+const CONTRIBUTORS_URL = `https://api.github.com/repos/${GITHUB_REPO_SLUG}/contributors?per_page=100`;
+
+interface GitHubContributor {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  contributions: number;
+  type: string;
+}
+
+export async function fetchContributors(): Promise<Contributor[]> {
+  try {
+    const response = await fetch(CONTRIBUTORS_URL, {
+      headers: { Accept: "application/vnd.github+json" },
+      next: { revalidate: CONTRIBUTORS_REVALIDATE_SECONDS },
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const data = (await response.json()) as GitHubContributor[];
+
+    return data
+      .filter((contributor) => contributor.type !== "Bot")
+      .sort((a, b) => b.contributions - a.contributions)
+      .map((contributor) => ({
+        username: contributor.login,
+        avatarUrl: contributor.avatar_url,
+        githubUrl: contributor.html_url,
+        contributions: contributor.contributions,
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -153,6 +153,13 @@ export interface HallOfFameEntry {
   country?: string;
 }
 
+export interface Contributor {
+  username: string;
+  avatarUrl: string;
+  githubUrl: string;
+  contributions: number;
+}
+
 export interface OrderItem {
   id: string;
   orderId: string;


### PR DESCRIPTION
## Description

Display project contributors alongside players on the Hall of Fame page, splitting it into two groups on the same page:

- **Players** (existing): people who completed all challenges, self-submitted via PR to `hall-of-fame/data.json`.
- **Contributors** (new): fetched from the GitHub API at build time. Bots are excluded and the list is sorted by contribution count. No auth token is used, on purpose: a real credential must never live in `process.env` of a deliberately vulnerable app (file-read / RCE challenges could exfiltrate it). Unauthenticated is enough given the ~1 request/day caused by ISR. The section is hidden if the fetch fails, so the page never breaks.

The "Join the Hall of Fame" CTA stays grouped with the players, and the contributors grid reuses the same hover animation as the player cards for visual consistency.

Also centralizes the repo URL: `lib/config` now exposes `GITHUB_REPO_SLUG` and derives `GITHUB_REPO` from it. All hardcoded repo URLs across the app (`Footer`, `PlayerDashboardClient`, `FlagChecker`, `hall-of-fame/page`, `contact/page`, `SupportBanner`) now import from it (DRY). The duplicated `TrophyIcon` / `GitHubIcon` SVGs were extracted to a shared `app/hall-of-fame/icons.tsx`.

## Type of change

- [ ] Bug fix
- [x] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [ ] Documentation update
- [ ] Other (please describe):

## Testing done

- `npx tsc --noEmit` passes with no errors.
- Verified contributors are fetched, bots filtered out, and sorted by contribution count.
- Confirmed the contributors section is hidden when the GitHub API is unreachable (graceful fallback).
- Checked layout, dark mode, and hover behavior on the Hall of Fame page (players + contributors).

## Checklist

- [x] Documentation updated (if applicable)

### If adding a new vulnerability

- [ ] Flag added in `prisma/seed.ts` with format `OSS{...}`
- [ ] Three progressive hints added in `prisma/seed.ts`
- [ ] Vulnerable code path is exploitable and demonstrable
- [ ] Reference doc added under `content/vulnerabilities/` (concept + fix only — no exploit steps, payloads, or flag value)
- [ ] Regression tests added (unit, API, and/or E2E)
- [ ] No real-world secrets introduced
- [ ] If a walkthrough was also added under `docs/src/data/blog/`, `walkthroughSlug` is set on the flag in `prisma/seed.ts`
