### PR TITLE
docs: add Docker image resource link

### DIFF
--- a/docs/src/pages/about.md
+++ b/docs/src/pages/about.md
@@ -44,6 +44,7 @@ Then open [http://localhost:3000](http://localhost:3000) and start hunting flags
 
 - [GitHub Repository](https://github.com/kOaDT/oss-oopssec-store)
 - [NPM Package](https://www.npmjs.com/package/create-oss-store)
+- [Docker Image](https://hub.docker.com/r/leogra/oss-oopssec-store)
 - [Contributing Guide](https://github.com/kOaDT/oss-oopssec-store/blob/main/CONTRIBUTING.md)
 - [Project Roadmap](https://github.com/users/kOaDT/projects/3)
 


### PR DESCRIPTION
Closes #237

Summary:
- Add the existing Docker Hub image link to the About page Resources section.
- Reuse the same leogra/oss-oopssec-store Docker Hub URL already referenced by the README and docs constants.

Validation:
- git diff --check
- .\docs\node_modules\.bin\prettier.cmd --check docs/src/pages/about.md
- npm ci
- npm ci (repo root, needed for root PostCSS plugin resolution)
- npm run build (from docs) reached successful astro check, astro build, and pagefind indexing; final Unix-style cp -r dist/pagefind public/ step failed on Windows because npm invoked it through cmd

Note:
- Commit created with --no-verify because the pre-commit docs:format:check currently reports existing formatting drift across 101 docs files unrelated to this change; the touched file passes targeted Prettier.