### PR TITLE
Feat/challenges json feed

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -36,6 +36,37 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+  docs:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint code
+        run: npm run lint
+
+      - name: Check code format
+        run: npm run format:check
+
+      # Mirrors the deploy-docs build so a broken walkthroughSlug (which fails
+      # the challenges.json route) surfaces on the PR, not after merge.
+      - name: Build Astro site
+        run: npm run build
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/EDUCATORS.md
+++ b/EDUCATORS.md
@@ -67,49 +67,49 @@ OopsSec Store covers the full **OWASP Top 10 (2025)** plus advanced topics relev
 
 A visual version of this catalog is available as the [Roadmap](https://koadt.github.io/oss-oopssec-store/roadmap) on the docs site, grouped into 11 thematic chapters.
 
-Building a tool around the curriculum? The same data is published as JSON at [`challenges.json`](https://koadt.github.io/oss-oopssec-store/challenges.json) — challenge number, title, difficulty, chapter, prerequisites and walkthrough URL, regenerated on every docs deploy.
+Building a tool around the curriculum? The same data is published as JSON at [`challenges.json`](https://koadt.github.io/oss-oopssec-store/challenges.json) — every column of the table below (number, title, chapter, category, difficulty, estimated minutes) plus prerequisites and the walkthrough URL, regenerated on every docs deploy.
 
 Difficulty: 🟢 Beginner · 🟡 Intermediate · 🔴 Advanced
 
-| #   | Challenge                                        | Category               | Difficulty | Est. time  |
-| --- | ------------------------------------------------ | ---------------------- | ---------- | ---------- |
-| 1   | Public Environment Variable Exposure             | Information Disclosure | 🟢         | 15–20 min  |
-| 2   | Information Disclosure via API Errors            | Information Disclosure | 🟢         | 15–20 min  |
-| 3   | IDOR - Private Orders Access                     | Broken Access Control  | 🟢         | 20–30 min  |
-| 4   | Open Redirect via Login Page                     | Input Validation       | 🟢         | 20–30 min  |
-| 5   | Stored XSS via Product Review                    | Injection              | 🟢         | 30–45 min  |
-| 6   | Self-XSS - Profile Bio Injection                 | Injection              | 🟢         | 20–30 min  |
-| 7   | SQL Injection (Login)                            | Injection              | 🟡         | 30–45 min  |
-| 8   | Product Search SQL Injection                     | Injection              | 🟡         | 30–45 min  |
-| 9   | Weak JWT Secret                                  | Authentication         | 🟡         | 45–60 min  |
-| 10  | Client-Side Price Manipulation                   | Input Validation       | 🟡         | 30–45 min  |
-| 11  | Weak MD5 Hashing                                 | Cryptographic          | 🟡         | 30–45 min  |
-| 12  | Cross-Site Request Forgery (CSRF)                | Request Forgery        | 🟡         | 45–60 min  |
-| 13  | Mass Assignment / Parameter Pollution            | Input Validation       | 🟡         | 45–60 min  |
-| 14  | Path Traversal                                   | Input Validation       | 🟡         | 30–45 min  |
-| 15  | Server-Side Request Forgery (SSRF)               | Request Forgery        | 🟡         | 45–60 min  |
-| 16  | Session Fixation & Weak Session Management       | Authentication         | 🟡         | 60–90 min  |
-| 17  | Brute Force - No Rate Limiting                   | Authentication         | 🟡         | 30–45 min  |
-| 18  | Insecure Password Reset                          | Authentication         | 🟡         | 45–60 min  |
-| 19  | Broken Object Level Authorization (BOLA)         | Authorization          | 🟡         | 45–60 min  |
-| 20  | Broken Function Level Authorization (BFLA)       | Authorization          | 🟡         | 45–60 min  |
-| 21  | Plaintext Password in Server Logs                | Information Disclosure | 🟡         | 30 min     |
-| 22  | Prompt Injection - AI Support Assistant          | Injection              | 🟡         | 60–90 min  |
-| 23  | Middleware Authorization Bypass (CVE-2025-29927) | Authorization          | 🟡         | 30–45 min  |
-| 24  | Insecure Randomness — Gift Card Code             | Cryptographic          | 🟡         | 45–60 min  |
-| 25  | AI Rules File Backdoor                           | Supply Chain           | 🟡         | 20–30 min  |
-| 26  | Second-Order SQL Injection                       | Injection              | 🔴         | 60–90 min  |
-| 27  | XXE - Supplier Import Endpoint                   | Injection              | 🔴         | 45–60 min  |
-| 28  | SVG Upload - Stored XSS                          | Injection              | 🔴         | 45–60 min  |
-| 29  | X-Forwarded-For SQL Injection                    | Injection              | 🔴         | 60–90 min  |
-| 30  | CSRF + Self-XSS Chain - Profile Takeover         | Request Forgery        | 🔴         | 90–120 min |
-| 31  | Padding Oracle - AES-CBC Token Forgery           | Cryptographic          | 🔴         | 90–120 min |
-| 32  | MCP Server Poisoning - Agent Manipulation        | Injection              | 🔴         | 90–120 min |
-| 33  | React2Shell - RSC RCE (CVE-2025-55182)           | RCE                    | 🔴         | 120+ min   |
-| 34  | Race Condition — Coupon Abuse                    | Business Logic         | 🔴         | 45–90 min  |
-| 35  | npm Supply Chain Typosquat                       | Supply Chain           | 🔴         | 60–90 min  |
+| #   | Challenge                                        | Chapter                     | Category               | Difficulty | Est. time  |
+| --- | ------------------------------------------------ | --------------------------- | ---------------------- | ---------- | ---------- |
+| 1   | Public Environment Variable Exposure             | Reconnaissance & Disclosure | Information Disclosure | 🟢         | 15–20 min  |
+| 2   | Information Disclosure via API Errors            | Reconnaissance & Disclosure | Information Disclosure | 🟢         | 15–20 min  |
+| 3   | Plaintext Password in Server Logs                | Reconnaissance & Disclosure | Information Disclosure | 🟡         | 30 min     |
+| 4   | IDOR - Private Orders Access                     | Broken Access Control       | Broken Access Control  | 🟢         | 20–30 min  |
+| 5   | Open Redirect via Login Page                     | Broken Access Control       | Input Validation       | 🟢         | 20–30 min  |
+| 6   | Broken Object Level Authorization (BOLA)         | Broken Access Control       | Authorization          | 🟡         | 45–60 min  |
+| 7   | Broken Function Level Authorization (BFLA)       | Broken Access Control       | Authorization          | 🟡         | 45–60 min  |
+| 8   | Path Traversal                                   | Broken Access Control       | Input Validation       | 🟡         | 30–45 min  |
+| 9   | Client-Side Price Manipulation                   | Trusting the Client         | Input Validation       | 🟡         | 30–45 min  |
+| 10  | Mass Assignment / Parameter Pollution            | Trusting the Client         | Input Validation       | 🟡         | 45–60 min  |
+| 11  | Middleware Authorization Bypass (CVE-2025-29927) | Trusting the Client         | Authorization          | 🟡         | 30–45 min  |
+| 12  | Race Condition — Coupon Abuse                    | Trusting the Client         | Business Logic         | 🔴         | 45–90 min  |
+| 13  | Stored XSS via Product Review                    | Cross-Site Attacks          | Injection              | 🟢         | 30–45 min  |
+| 14  | Self-XSS - Profile Bio Injection                 | Cross-Site Attacks          | Injection              | 🟢         | 20–30 min  |
+| 15  | Cross-Site Request Forgery (CSRF)                | Cross-Site Attacks          | Request Forgery        | 🟡         | 45–60 min  |
+| 16  | CSRF + Self-XSS Chain - Profile Takeover         | Cross-Site Attacks          | Request Forgery        | 🔴         | 90–120 min |
+| 17  | SQL Injection (Login)                            | SQL Injection Deep Dive     | Injection              | 🟡         | 30–45 min  |
+| 18  | Product Search SQL Injection                     | SQL Injection Deep Dive     | Injection              | 🟡         | 30–45 min  |
+| 19  | X-Forwarded-For SQL Injection                    | SQL Injection Deep Dive     | Injection              | 🔴         | 60–90 min  |
+| 20  | Second-Order SQL Injection                       | SQL Injection Deep Dive     | Injection              | 🔴         | 60–90 min  |
+| 21  | SVG Upload - Stored XSS                          | Parsers Behaving Badly      | Injection              | 🔴         | 45–60 min  |
+| 22  | XXE - Supplier Import Endpoint                   | Parsers Behaving Badly      | Injection              | 🔴         | 45–60 min  |
+| 23  | Weak JWT Secret                                  | Authentication Failures     | Authentication         | 🟡         | 45–60 min  |
+| 24  | Brute Force - No Rate Limiting                   | Authentication Failures     | Authentication         | 🟡         | 30–45 min  |
+| 25  | Session Fixation & Weak Session Management       | Authentication Failures     | Authentication         | 🟡         | 60–90 min  |
+| 26  | Insecure Password Reset                          | Authentication Failures     | Authentication         | 🟡         | 45–60 min  |
+| 27  | Server-Side Request Forgery (SSRF)               | Server-Side Request Forgery | Request Forgery        | 🟡         | 45–60 min  |
+| 28  | Weak MD5 Hashing                                 | Cryptography Done Wrong     | Cryptographic          | 🟡         | 30–45 min  |
+| 29  | Insecure Randomness — Gift Card Code             | Cryptography Done Wrong     | Cryptographic          | 🟡         | 45–60 min  |
+| 30  | Padding Oracle - AES-CBC Token Forgery           | Cryptography Done Wrong     | Cryptographic          | 🔴         | 90–120 min |
+| 31  | Prompt Injection - AI Support Assistant          | AI & LLM Security           | Injection              | 🟡         | 60–90 min  |
+| 32  | MCP Server Poisoning - Agent Manipulation        | AI & LLM Security           | Injection              | 🔴         | 90–120 min |
+| 33  | npm Supply Chain Typosquat                       | Supply Chain & Framework    | Supply Chain           | 🔴         | 60–90 min  |
+| 34  | AI Rules File Backdoor                           | Supply Chain & Framework    | Supply Chain           | 🟡         | 20–30 min  |
+| 35  | React2Shell - RSC RCE (CVE-2025-55182)           | Supply Chain & Framework    | RCE                    | 🔴         | 120+ min   |
 
-**Total estimated time:** 33–48 hours for the full curriculum depending on student level. Challenges 25 and 35 are chained — once the chain is started for flag #35, flag #25 follows in a few minutes.
+**Total estimated time:** 26–36 hours for the full curriculum depending on student level. Challenges 33 and 34 are chained — once the chain is started for flag #33, flag #34 follows in a few minutes.
 You don't need to cover everything. Pick the challenges that match your course objectives and time constraints.
 
 ---
@@ -184,10 +184,10 @@ npx create-oss-store my-lab && cd my-lab && npm start
 Designed for pentesters or developers onboarding to a security-aware team.
 
 **Recommended path for developers** (focus on understanding, not exploitation):
-Challenges 1–6 (recon & basics) → 7–8 (SQLi) → 12 (CSRF) → 14 (Path Traversal) → 21 (Prompt Injection). Focus on the "How to Fix" section of each walkthrough.
+Public Env Variable, Info Disclosure API, IDOR, Open Redirect, Stored XSS, Self-XSS (recon & basics) → SQL Injection (login), Product Search SQLi → CSRF → Path Traversal → Prompt Injection. Focus on the "How to Fix" section of each walkthrough.
 
 **Recommended path for junior pentesters** (focus on technique):
-Full catalog in order of difficulty. Target: complete all 35 challenges in 4–5 weeks of part-time practice.
+Full catalog in roadmap order. Target: complete all 35 challenges in 4–5 weeks of part-time practice.
 
 ---
 

--- a/EDUCATORS.md
+++ b/EDUCATORS.md
@@ -67,6 +67,8 @@ OopsSec Store covers the full **OWASP Top 10 (2025)** plus advanced topics relev
 
 A visual version of this catalog is available as the [Roadmap](https://koadt.github.io/oss-oopssec-store/roadmap) on the docs site, grouped into 11 thematic chapters.
 
+Building a tool around the curriculum? The same data is published as JSON at [`challenges.json`](https://koadt.github.io/oss-oopssec-store/challenges.json) — challenge number, title, difficulty, chapter, prerequisites and walkthrough URL, regenerated on every docs deploy.
+
 Difficulty: 🟢 Beginner · 🟡 Intermediate · 🔴 Advanced
 
 | #   | Challenge                                        | Category               | Difficulty | Est. time  |

--- a/EDUCATORS.md
+++ b/EDUCATORS.md
@@ -67,47 +67,49 @@ OopsSec Store covers the full **OWASP Top 10 (2025)** plus advanced topics relev
 
 A visual version of this catalog is available as the [Roadmap](https://koadt.github.io/oss-oopssec-store/roadmap) on the docs site, grouped into 11 thematic chapters.
 
-Building a tool around the curriculum? The same data is published as JSON at [`challenges.json`](https://koadt.github.io/oss-oopssec-store/challenges.json) — every column of the table below (number, title, chapter, category, difficulty, estimated minutes) plus prerequisites and the walkthrough URL, regenerated on every docs deploy.
+Building a tool around the curriculum? The same data is published as JSON at [`challenges.json`](https://koadt.github.io/oss-oopssec-store/challenges.json) — every column of the table below (number, title, chapter, category, difficulty, estimated minutes) plus prerequisites and the walkthrough URL, regenerated on every docs deploy. Note that `walkthrough.slug` is not a unique key — a chained challenge shares its write-up with the challenge it builds on (14 and 16, 33 and 34), so deduplicating on it would drop entries.
 
 Difficulty: 🟢 Beginner · 🟡 Intermediate · 🔴 Advanced
 
-| #   | Challenge                                        | Chapter                     | Category               | Difficulty | Est. time  |
-| --- | ------------------------------------------------ | --------------------------- | ---------------------- | ---------- | ---------- |
-| 1   | Public Environment Variable Exposure             | Reconnaissance & Disclosure | Information Disclosure | 🟢         | 15–20 min  |
-| 2   | Information Disclosure via API Errors            | Reconnaissance & Disclosure | Information Disclosure | 🟢         | 15–20 min  |
-| 3   | Plaintext Password in Server Logs                | Reconnaissance & Disclosure | Information Disclosure | 🟡         | 30 min     |
-| 4   | IDOR - Private Orders Access                     | Broken Access Control       | Broken Access Control  | 🟢         | 20–30 min  |
-| 5   | Open Redirect via Login Page                     | Broken Access Control       | Input Validation       | 🟢         | 20–30 min  |
-| 6   | Broken Object Level Authorization (BOLA)         | Broken Access Control       | Authorization          | 🟡         | 45–60 min  |
-| 7   | Broken Function Level Authorization (BFLA)       | Broken Access Control       | Authorization          | 🟡         | 45–60 min  |
-| 8   | Path Traversal                                   | Broken Access Control       | Input Validation       | 🟡         | 30–45 min  |
-| 9   | Client-Side Price Manipulation                   | Trusting the Client         | Input Validation       | 🟡         | 30–45 min  |
-| 10  | Mass Assignment / Parameter Pollution            | Trusting the Client         | Input Validation       | 🟡         | 45–60 min  |
-| 11  | Middleware Authorization Bypass (CVE-2025-29927) | Trusting the Client         | Authorization          | 🟡         | 30–45 min  |
-| 12  | Race Condition — Coupon Abuse                    | Trusting the Client         | Business Logic         | 🔴         | 45–90 min  |
-| 13  | Stored XSS via Product Review                    | Cross-Site Attacks          | Injection              | 🟢         | 30–45 min  |
-| 14  | Self-XSS - Profile Bio Injection                 | Cross-Site Attacks          | Injection              | 🟢         | 20–30 min  |
-| 15  | Cross-Site Request Forgery (CSRF)                | Cross-Site Attacks          | Request Forgery        | 🟡         | 45–60 min  |
-| 16  | CSRF + Self-XSS Chain - Profile Takeover         | Cross-Site Attacks          | Request Forgery        | 🔴         | 90–120 min |
-| 17  | SQL Injection (Login)                            | SQL Injection Deep Dive     | Injection              | 🟡         | 30–45 min  |
-| 18  | Product Search SQL Injection                     | SQL Injection Deep Dive     | Injection              | 🟡         | 30–45 min  |
-| 19  | X-Forwarded-For SQL Injection                    | SQL Injection Deep Dive     | Injection              | 🔴         | 60–90 min  |
-| 20  | Second-Order SQL Injection                       | SQL Injection Deep Dive     | Injection              | 🔴         | 60–90 min  |
-| 21  | SVG Upload - Stored XSS                          | Parsers Behaving Badly      | Injection              | 🔴         | 45–60 min  |
-| 22  | XXE - Supplier Import Endpoint                   | Parsers Behaving Badly      | Injection              | 🔴         | 45–60 min  |
-| 23  | Weak JWT Secret                                  | Authentication Failures     | Authentication         | 🟡         | 45–60 min  |
-| 24  | Brute Force - No Rate Limiting                   | Authentication Failures     | Authentication         | 🟡         | 30–45 min  |
-| 25  | Session Fixation & Weak Session Management       | Authentication Failures     | Authentication         | 🟡         | 60–90 min  |
-| 26  | Insecure Password Reset                          | Authentication Failures     | Authentication         | 🟡         | 45–60 min  |
-| 27  | Server-Side Request Forgery (SSRF)               | Server-Side Request Forgery | Request Forgery        | 🟡         | 45–60 min  |
-| 28  | Weak MD5 Hashing                                 | Cryptography Done Wrong     | Cryptographic          | 🟡         | 30–45 min  |
-| 29  | Insecure Randomness — Gift Card Code             | Cryptography Done Wrong     | Cryptographic          | 🟡         | 45–60 min  |
-| 30  | Padding Oracle - AES-CBC Token Forgery           | Cryptography Done Wrong     | Cryptographic          | 🔴         | 90–120 min |
-| 31  | Prompt Injection - AI Support Assistant          | AI & LLM Security           | Injection              | 🟡         | 60–90 min  |
-| 32  | MCP Server Poisoning - Agent Manipulation        | AI & LLM Security           | Injection              | 🔴         | 90–120 min |
-| 33  | npm Supply Chain Typosquat                       | Supply Chain & Framework    | Supply Chain           | 🔴         | 60–90 min  |
-| 34  | AI Rules File Backdoor                           | Supply Chain & Framework    | Supply Chain           | 🟡         | 20–30 min  |
-| 35  | React2Shell - RSC RCE (CVE-2025-55182)           | Supply Chain & Framework    | RCE                    | 🔴         | 120+ min   |
+The Category column uses the same vocabulary as the app's `FlagCategory` enum (`AUTHORIZATION`, `INSECURE_DESIGN`, `REMOTE_CODE_EXECUTION`…), spelled out here for readability, so the table, the JSON feed and `/api/flags` all agree.
+
+| #   | Challenge                                                | Chapter                     | Category               | Difficulty | Est. time  |
+| --- | -------------------------------------------------------- | --------------------------- | ---------------------- | ---------- | ---------- |
+| 1   | Public env variable leak                                 | Reconnaissance & Disclosure | Information Disclosure | 🟢         | 15–20 min  |
+| 2   | Information disclosure via API errors                    | Reconnaissance & Disclosure | Information Disclosure | 🟢         | 15–20 min  |
+| 3   | Plaintext passwords in logs                              | Reconnaissance & Disclosure | Information Disclosure | 🟡         | 30 min     |
+| 4   | Insecure Direct Object Reference (IDOR)                  | Broken Access Control       | Authorization          | 🟢         | 20–30 min  |
+| 5   | Open redirect to login bypass                            | Broken Access Control       | Input Validation       | 🟢         | 20–30 min  |
+| 6   | Broken Object Level Authorization (BOLA)                 | Broken Access Control       | Authorization          | 🟡         | 45–60 min  |
+| 7   | Broken Function Level Authorization (live stream hijack) | Broken Access Control       | Authorization          | 🟡         | 45–60 min  |
+| 8   | Path traversal in document API                           | Broken Access Control       | Input Validation       | 🟡         | 30–45 min  |
+| 9   | Client-side price manipulation                           | Trusting the Client         | Input Validation       | 🟡         | 30–45 min  |
+| 10  | Mass assignment to admin role                            | Trusting the Client         | Input Validation       | 🟡         | 45–60 min  |
+| 11  | Middleware bypass (CVE-2025-29927)                       | Trusting the Client         | Authorization          | 🟡         | 30–45 min  |
+| 12  | Race condition coupon abuse                              | Trusting the Client         | Insecure Design        | 🔴         | 45–90 min  |
+| 13  | Stored XSS in product reviews                            | Cross-Site Attacks          | Injection              | 🟢         | 30–45 min  |
+| 14  | Self-XSS in profile bio                                  | Cross-Site Attacks          | Injection              | 🟢         | 20–30 min  |
+| 15  | CSRF on admin order update                               | Cross-Site Attacks          | Request Forgery        | 🟡         | 45–60 min  |
+| 16  | CSRF + Self-XSS profile takeover                         | Cross-Site Attacks          | Request Forgery        | 🔴         | 90–120 min |
+| 17  | SQL injection in order search                            | SQL Injection Deep Dive     | Injection              | 🟡         | 30–45 min  |
+| 18  | Product search SQLi                                      | SQL Injection Deep Dive     | Injection              | 🟡         | 30–45 min  |
+| 19  | X-Forwarded-For SQLi                                     | SQL Injection Deep Dive     | Injection              | 🔴         | 60–90 min  |
+| 20  | Second-order SQL injection                               | SQL Injection Deep Dive     | Injection              | 🔴         | 60–90 min  |
+| 21  | Malicious file upload (SVG XSS)                          | Parsers Behaving Badly      | Injection              | 🔴         | 45–60 min  |
+| 22  | XXE in supplier order import                             | Parsers Behaving Badly      | Injection              | 🔴         | 45–60 min  |
+| 23  | Weak JWT secret                                          | Authentication Failures     | Authentication         | 🟡         | 45–60 min  |
+| 24  | Brute force, no rate limiting                            | Authentication Failures     | Authentication         | 🟡         | 30–45 min  |
+| 25  | Session fixation                                         | Authentication Failures     | Authentication         | 🟡         | 60–90 min  |
+| 26  | Insecure password reset                                  | Authentication Failures     | Authentication         | 🟡         | 45–60 min  |
+| 27  | SSRF internal page access                                | Server-Side Request Forgery | Request Forgery        | 🟡         | 45–60 min  |
+| 28  | Weak MD5 password hashing                                | Cryptography Done Wrong     | Cryptographic          | 🟡         | 30–45 min  |
+| 29  | Insecure randomness in gift cards                        | Cryptography Done Wrong     | Cryptographic          | 🟡         | 45–60 min  |
+| 30  | AES-CBC padding oracle                                   | Cryptography Done Wrong     | Cryptographic          | 🔴         | 90–120 min |
+| 31  | Prompt injection in AI assistant                         | AI & LLM Security           | Injection              | 🟡         | 60–90 min  |
+| 32  | MCP malicious server                                     | AI & LLM Security           | Injection              | 🔴         | 90–120 min |
+| 33  | npm typosquat                                            | Supply Chain & Framework    | Supply Chain           | 🔴         | 60–90 min  |
+| 34  | AI rules file backdoor                                   | Supply Chain & Framework    | Supply Chain           | 🟡         | 20–30 min  |
+| 35  | react2shell (CVE-2025-55182)                             | Supply Chain & Framework    | Remote Code Execution  | 🔴         | 120+ min   |
 
 **Total estimated time:** 26–36 hours for the full curriculum depending on student level. Challenges 33 and 34 are chained — once the chain is started for flag #33, flag #34 follows in a few minutes.
 You don't need to cover everything. Pick the challenges that match your course objectives and time constraints.

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -14,7 +14,7 @@ export const SITE = {
   editPost: {
     enabled: true,
     text: "Edit page",
-    url: "https://github.com/kOaDT/oss-oopssec-store/edit/develop/docs/",
+    url: "https://github.com/kOaDT/oss-oopssec-store/edit/main/docs/",
   },
   dynamicOgImage: true,
   dir: "ltr", // "rtl" | "auto"

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -1,8 +1,31 @@
 export type Difficulty = "EASY" | "MEDIUM" | "HARD";
 
+/** Vulnerability class. Mirrors the `FlagCategory` enum of
+ * `prisma/schema.prisma` verbatim so a consumer can join challenges.json with
+ * the app's `/api/flags` on this field. Keep the two in sync: adding a value
+ * here without adding it to the enum breaks that join. */
+export type Category =
+  | "INJECTION"
+  | "AUTHENTICATION"
+  | "AUTHORIZATION"
+  | "REQUEST_FORGERY"
+  | "INFORMATION_DISCLOSURE"
+  | "INPUT_VALIDATION"
+  | "CRYPTOGRAPHIC"
+  | "REMOTE_CODE_EXECUTION"
+  | "INSECURE_DESIGN"
+  | "SUPPLY_CHAIN"
+  | "OTHER";
+
+/** Hands-on time to expect, as `[min, max]` minutes. A null max means
+ * open-ended ("120+ min"); equal bounds mean a single estimate ("30 min"). */
+export type EstimatedMinutes = [number, number | null];
+
 export interface Challenge {
   title: string;
   difficulty: Difficulty;
+  category: Category;
+  estimatedMinutes: EstimatedMinutes;
   walkthroughSlug: string;
   /** Global challenge numbers (1-indexed across the curriculum) that the
    * learner should ideally have completed first. Rendered as a "Builds on"
@@ -24,16 +47,22 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "Public env variable leak",
         difficulty: "EASY",
+        category: "INFORMATION_DISCLOSURE",
+        estimatedMinutes: [15, 20],
         walkthroughSlug: "next-public-env-variable-leak",
       },
       {
         title: "Information disclosure via API errors",
         difficulty: "EASY",
+        category: "INFORMATION_DISCLOSURE",
+        estimatedMinutes: [15, 20],
         walkthroughSlug: "information-disclosure-api-error",
       },
       {
         title: "Plaintext passwords in logs",
         difficulty: "MEDIUM",
+        category: "INFORMATION_DISCLOSURE",
+        estimatedMinutes: [30, 30],
         walkthroughSlug: "plaintext-password-in-logs",
       },
     ],
@@ -45,26 +74,36 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "Insecure Direct Object Reference (IDOR)",
         difficulty: "EASY",
+        category: "AUTHORIZATION",
+        estimatedMinutes: [20, 30],
         walkthroughSlug: "idor-order-privacy-breach",
       },
       {
         title: "Open redirect to login bypass",
         difficulty: "EASY",
+        category: "INPUT_VALIDATION",
+        estimatedMinutes: [20, 30],
         walkthroughSlug: "open-redirect-login-bypass",
       },
       {
         title: "Broken Object Level Authorization (BOLA)",
         difficulty: "MEDIUM",
+        category: "AUTHORIZATION",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "bola-wishlist-access",
       },
       {
         title: "Broken Function Level Authorization (live stream hijack)",
         difficulty: "MEDIUM",
+        category: "AUTHORIZATION",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "live-stream-hijack",
       },
       {
         title: "Path traversal in document API",
         difficulty: "MEDIUM",
+        category: "INPUT_VALIDATION",
+        estimatedMinutes: [30, 45],
         walkthroughSlug: "path-traversal-documents-api",
       },
     ],
@@ -76,21 +115,29 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "Client-side price manipulation",
         difficulty: "MEDIUM",
+        category: "INPUT_VALIDATION",
+        estimatedMinutes: [30, 45],
         walkthroughSlug: "client-side-price-manipulation",
       },
       {
         title: "Mass assignment to admin role",
         difficulty: "MEDIUM",
+        category: "INPUT_VALIDATION",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "mass-assignment-admin-privilege-escalation",
       },
       {
         title: "Middleware bypass (CVE-2025-29927)",
         difficulty: "MEDIUM",
+        category: "AUTHORIZATION",
+        estimatedMinutes: [30, 45],
         walkthroughSlug: "middleware-authorization-bypass-cve-2025-29927",
       },
       {
         title: "Race condition coupon abuse",
         difficulty: "HARD",
+        category: "INSECURE_DESIGN",
+        estimatedMinutes: [45, 90],
         walkthroughSlug: "race-condition-coupon-abuse",
       },
     ],
@@ -102,21 +149,29 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "Stored XSS in product reviews",
         difficulty: "EASY",
+        category: "INJECTION",
+        estimatedMinutes: [30, 45],
         walkthroughSlug: "stored-xss-product-reviews",
       },
       {
         title: "Self-XSS in profile bio",
         difficulty: "EASY",
+        category: "INJECTION",
+        estimatedMinutes: [20, 30],
         walkthroughSlug: "self-xss-csrf-profile-takeover",
       },
       {
         title: "CSRF on admin order update",
         difficulty: "MEDIUM",
+        category: "REQUEST_FORGERY",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "csrf-admin-order-update",
       },
       {
         title: "CSRF + Self-XSS profile takeover",
         difficulty: "HARD",
+        category: "REQUEST_FORGERY",
+        estimatedMinutes: [90, 120],
         walkthroughSlug: "self-xss-csrf-profile-takeover",
         prerequisites: [14, 15],
       },
@@ -129,22 +184,30 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "SQL injection in order search",
         difficulty: "MEDIUM",
+        category: "INJECTION",
+        estimatedMinutes: [30, 45],
         walkthroughSlug: "sql-injection-writeup",
       },
       {
         title: "Product search SQLi",
         difficulty: "MEDIUM",
+        category: "INJECTION",
+        estimatedMinutes: [30, 45],
         walkthroughSlug: "product-search-sql-injection",
       },
       {
         title: "X-Forwarded-For SQLi",
         difficulty: "HARD",
+        category: "INJECTION",
+        estimatedMinutes: [60, 90],
         walkthroughSlug: "x-forwarded-for-sql-injection",
         prerequisites: [17, 18],
       },
       {
         title: "Second-order SQL injection",
         difficulty: "HARD",
+        category: "INJECTION",
+        estimatedMinutes: [60, 90],
         walkthroughSlug: "second-order-sql-injection",
         prerequisites: [17, 18],
       },
@@ -157,11 +220,15 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "Malicious file upload (SVG XSS)",
         difficulty: "HARD",
+        category: "INJECTION",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "malicious-file-upload-stored-xss",
       },
       {
         title: "XXE in supplier order import",
         difficulty: "HARD",
+        category: "INJECTION",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "xxe-supplier-order-import",
       },
     ],
@@ -173,21 +240,29 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "Weak JWT secret",
         difficulty: "MEDIUM",
+        category: "AUTHENTICATION",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "jwt-weak-secret-admin-bypass",
       },
       {
         title: "Brute force, no rate limiting",
         difficulty: "MEDIUM",
+        category: "AUTHENTICATION",
+        estimatedMinutes: [30, 45],
         walkthroughSlug: "brute-force-no-rate-limiting",
       },
       {
         title: "Session fixation",
         difficulty: "MEDIUM",
+        category: "AUTHENTICATION",
+        estimatedMinutes: [60, 90],
         walkthroughSlug: "session-fixation-weak-session-management",
       },
       {
         title: "Insecure password reset",
         difficulty: "MEDIUM",
+        category: "AUTHENTICATION",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "insecure-password-reset",
       },
     ],
@@ -199,6 +274,8 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "SSRF internal page access",
         difficulty: "MEDIUM",
+        category: "REQUEST_FORGERY",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "ssrf-internal-page-access",
       },
     ],
@@ -210,16 +287,22 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "Weak MD5 password hashing",
         difficulty: "MEDIUM",
+        category: "CRYPTOGRAPHIC",
+        estimatedMinutes: [30, 45],
         walkthroughSlug: "weak-md5-hashing-admin-compromise",
       },
       {
         title: "Insecure randomness in gift cards",
         difficulty: "MEDIUM",
+        category: "CRYPTOGRAPHIC",
+        estimatedMinutes: [45, 60],
         walkthroughSlug: "insecure-randomness-gift-card",
       },
       {
         title: "AES-CBC padding oracle",
         difficulty: "HARD",
+        category: "CRYPTOGRAPHIC",
+        estimatedMinutes: [90, 120],
         walkthroughSlug: "aes-cbc-padding-oracle-forged-share-token",
       },
     ],
@@ -231,11 +314,15 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "Prompt injection in AI assistant",
         difficulty: "MEDIUM",
+        category: "INJECTION",
+        estimatedMinutes: [60, 90],
         walkthroughSlug: "prompt-injection-ai-assistant",
       },
       {
         title: "MCP malicious server",
         difficulty: "HARD",
+        category: "INJECTION",
+        estimatedMinutes: [90, 120],
         walkthroughSlug: "mcp-malicious-server",
       },
     ],
@@ -247,16 +334,22 @@ export const CURRICULUM: Chapter[] = [
       {
         title: "npm typosquat",
         difficulty: "HARD",
+        category: "SUPPLY_CHAIN",
+        estimatedMinutes: [60, 90],
         walkthroughSlug: "supply-chain-poisoned-rules-chain",
       },
       {
         title: "AI rules file backdoor",
         difficulty: "MEDIUM",
+        category: "SUPPLY_CHAIN",
+        estimatedMinutes: [20, 30],
         walkthroughSlug: "supply-chain-poisoned-rules-chain",
       },
       {
         title: "react2shell (CVE-2025-55182)",
         difficulty: "HARD",
+        category: "REMOTE_CODE_EXECUTION",
+        estimatedMinutes: [120, null],
         walkthroughSlug: "react2shell-cve-2025-55182",
       },
     ],

--- a/docs/src/pages/about.md
+++ b/docs/src/pages/about.md
@@ -47,6 +47,7 @@ Then open [http://localhost:3000](http://localhost:3000) and start hunting flags
 - [Docker Image](https://hub.docker.com/r/leogra/oss-oopssec-store)
 - [Contributing Guide](https://github.com/kOaDT/oss-oopssec-store/blob/main/CONTRIBUTING.md)
 - [Project Roadmap](https://github.com/users/kOaDT/projects/3)
+- [Challenge feed (JSON)](https://koadt.github.io/oss-oopssec-store/challenges.json) - the curriculum in machine-readable form
 
 ## Disclaimer
 

--- a/docs/src/pages/challenges.json.ts
+++ b/docs/src/pages/challenges.json.ts
@@ -4,6 +4,7 @@ import { SITE } from "@/config";
 import {
   CHALLENGES_BY_DIFFICULTY,
   TOTAL_CHALLENGES,
+  type Category,
   type Difficulty,
 } from "@/data/roadmap";
 import { getPath } from "@/utils/getPath";
@@ -35,6 +36,10 @@ interface FeedChallenge {
   number: number;
   title: string;
   difficulty: Difficulty;
+  /** Matches the app's `FlagCategory` enum, so this joins with `/api/flags`. */
+  category: Category;
+  /** Hands-on minutes to expect. A null `max` means open-ended. */
+  estimatedMinutes: { min: number; max: number | null };
   url: string;
   chapter: FeedChapter;
   prerequisites: number[];
@@ -59,9 +64,9 @@ export const GET: APIRoute = async ({ site }) => {
   const base = import.meta.env.BASE_URL.replace(/\/$/, "");
   const roadmapUrl = absolute(`${base}/roadmap`);
 
-  const posts = await getCollection("blog", postFilter);
+  const allPosts = await getCollection("blog");
   const walkthroughs = new Map<string, FeedWalkthrough>(
-    posts.map(({ id, filePath, data }) => [
+    allPosts.filter(postFilter).map(({ id, filePath, data }) => [
       id,
       {
         slug: id,
@@ -71,6 +76,25 @@ export const GET: APIRoute = async ({ site }) => {
       },
     ])
   );
+
+  /* A walkthroughSlug matching no post at all is a rename or a deletion, not a
+   * draft: it would ship a null into a public artifact and 404 the matching
+   * roadmap link. Fail the build rather than let it through silently. Posts
+   * that exist but are filtered out (draft, scheduled) stay a legitimate null. */
+  const known = new Set(allPosts.map(({ id }) => id));
+  const orphans = [
+    ...new Set(
+      getChallenges()
+        .map(({ slug }) => slug)
+        .filter(slug => !known.has(slug))
+    ),
+  ];
+  if (orphans.length > 0) {
+    throw new Error(
+      `challenges.json: no walkthrough post found for ${orphans.join(", ")} — ` +
+        `check walkthroughSlug in src/data/roadmap.ts`
+    );
+  }
 
   const feed: ChallengeFeed = {
     version: FEED_VERSION,
@@ -83,6 +107,11 @@ export const GET: APIRoute = async ({ site }) => {
       number: entry.number,
       title: entry.title,
       difficulty: entry.difficulty,
+      category: entry.category,
+      estimatedMinutes: {
+        min: entry.estimatedMinutes[0],
+        max: entry.estimatedMinutes[1],
+      },
       url: `${roadmapUrl}#${challengeAnchorId(entry.number)}`,
       chapter: {
         index: entry.chapterIndex,

--- a/docs/src/pages/challenges.json.ts
+++ b/docs/src/pages/challenges.json.ts
@@ -1,0 +1,101 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { SITE } from "@/config";
+import {
+  CHALLENGES_BY_DIFFICULTY,
+  TOTAL_CHALLENGES,
+  type Difficulty,
+} from "@/data/roadmap";
+import { getPath } from "@/utils/getPath";
+import {
+  challengeAnchorId,
+  chapterAnchorId,
+  getChallenges,
+} from "@/utils/getRoadmapContext";
+import postFilter from "@/utils/postFilter";
+
+/** Bump on any breaking change to the payload shape below. */
+const FEED_VERSION = 1;
+
+interface FeedWalkthrough {
+  slug: string;
+  title: string;
+  description: string;
+  url: string;
+}
+
+interface FeedChapter {
+  index: number;
+  title: string;
+  tagline: string;
+  url: string;
+}
+
+interface FeedChallenge {
+  number: number;
+  title: string;
+  difficulty: Difficulty;
+  url: string;
+  chapter: FeedChapter;
+  prerequisites: number[];
+  /** Null while the walkthrough is unwritten, a draft, or still scheduled. */
+  walkthrough: FeedWalkthrough | null;
+}
+
+interface ChallengeFeed {
+  version: number;
+  generatedAt: string;
+  site: string;
+  roadmapUrl: string;
+  totalChallenges: number;
+  challengesByDifficulty: Record<Difficulty, number>;
+  challenges: FeedChallenge[];
+}
+
+export const GET: APIRoute = async ({ site }) => {
+  const origin = site ?? new URL(SITE.website);
+  const absolute = (path: string) => new URL(path, origin).href;
+
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  const roadmapUrl = absolute(`${base}/roadmap`);
+
+  const posts = await getCollection("blog", postFilter);
+  const walkthroughs = new Map<string, FeedWalkthrough>(
+    posts.map(({ id, filePath, data }) => [
+      id,
+      {
+        slug: id,
+        title: data.title,
+        description: data.description,
+        url: absolute(getPath(id, filePath)),
+      },
+    ])
+  );
+
+  const feed: ChallengeFeed = {
+    version: FEED_VERSION,
+    generatedAt: new Date().toISOString(),
+    site: origin.href,
+    roadmapUrl,
+    totalChallenges: TOTAL_CHALLENGES,
+    challengesByDifficulty: CHALLENGES_BY_DIFFICULTY,
+    challenges: getChallenges().map(entry => ({
+      number: entry.number,
+      title: entry.title,
+      difficulty: entry.difficulty,
+      url: `${roadmapUrl}#${challengeAnchorId(entry.number)}`,
+      chapter: {
+        index: entry.chapterIndex,
+        title: entry.chapterTitle,
+        tagline: entry.chapterTagline,
+        url: `${roadmapUrl}#${chapterAnchorId(entry.chapterIndex)}`,
+      },
+      prerequisites: entry.prerequisites,
+      walkthrough: walkthroughs.get(entry.slug) ?? null,
+    })),
+  };
+
+  return new Response(JSON.stringify(feed), {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+};

--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -172,7 +172,7 @@ const pageDesc = `${CURRICULUM.length} chapters covering the bug classes that sh
           <div class="track-stat-label">Easy / Med / Hard</div>
         </div>
         <div class="track-stat">
-          <div class="track-stat-value">33–48h</div>
+          <div class="track-stat-value">26-36h</div>
           <div class="track-stat-label">To finish</div>
         </div>
       </section>

--- a/docs/src/pages/roadmap/index.astro
+++ b/docs/src/pages/roadmap/index.astro
@@ -13,6 +13,11 @@ import {
   CHALLENGES_BY_DIFFICULTY,
   type Difficulty,
 } from "@/data/roadmap";
+import {
+  chapterAnchorId,
+  challengeAnchorId,
+  formatRoadmapNumber as pad,
+} from "@/utils/getRoadmapContext";
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 
@@ -110,7 +115,6 @@ const sections: Section[] = CURRICULUM.map((chapter, ci) => {
 });
 
 const backUrl = SITE.showBackButton ? Astro.url.pathname : `${base}/`;
-const pad = (n: number) => String(n).padStart(2, "0");
 
 const pageTitle = "The Roadmap";
 const pageDesc = `${CURRICULUM.length} chapters covering the bug classes that ship in real production code, from the obvious versions to the ones that survive a code review.`;
@@ -131,7 +135,7 @@ const pageDesc = `${CURRICULUM.length} chapters covering the bug classes that sh
           CURRICULUM.map((chapter, ci) => (
             <li>
               <a
-                href={`#chapter-${pad(ci + 1)}`}
+                href={`#${chapterAnchorId(ci + 1)}`}
                 class="track-toc-link"
                 data-chapter-link={pad(ci + 1)}
               >
@@ -218,7 +222,7 @@ const pageDesc = `${CURRICULUM.length} chapters covering the bug classes that sh
           sections.map(section => (
             <section
               class:list={["track-section", `track-section--${section.side}`]}
-              id={`chapter-${pad(section.index)}`}
+              id={chapterAnchorId(section.index)}
               data-chapter-id={pad(section.index)}
               style={`--section-h: ${section.sectionHeight}px;`}
             >
@@ -267,7 +271,7 @@ const pageDesc = `${CURRICULUM.length} chapters covering the bug classes that sh
                   return (
                     <li
                       class="challenge-item"
-                      id={`challenge-${pad(number)}`}
+                      id={challengeAnchorId(number)}
                       data-prereqs-followed={
                         needsPrereqsGap ? "true" : undefined
                       }
@@ -316,7 +320,7 @@ const pageDesc = `${CURRICULUM.length} chapters covering the bug classes that sh
                                   </span>
                                 )}
                                 <a
-                                  href={`#challenge-${pad(n)}`}
+                                  href={`#${challengeAnchorId(n)}`}
                                   class="challenge-prereqs-link"
                                   aria-label={`Jump to challenge ${pad(n)}`}
                                 >

--- a/docs/src/utils/getRoadmapContext.ts
+++ b/docs/src/utils/getRoadmapContext.ts
@@ -67,6 +67,19 @@ const byNumber = new Map<number, RoadmapEntry>(
   entries.map(entry => [entry.number, entry])
 );
 
+/** Zero-padded challenge or chapter number, e.g. 7 -> "07". */
+export const formatRoadmapNumber = (n: number): string =>
+  String(n).padStart(2, "0");
+
+export const chapterAnchorId = (index: number): string =>
+  `chapter-${formatRoadmapNumber(index)}`;
+
+export const challengeAnchorId = (number: number): string =>
+  `challenge-${formatRoadmapNumber(number)}`;
+
+/** Every challenge in curriculum order, one entry per challenge. */
+export const getChallenges = (): RoadmapEntry[] => [...entries];
+
 export const getRoadmapContext = (slug: string): RoadmapEntry | null =>
   bySlug.get(slug) ?? null;
 

--- a/docs/src/utils/getRoadmapContext.ts
+++ b/docs/src/utils/getRoadmapContext.ts
@@ -1,4 +1,9 @@
-import { CURRICULUM, type Difficulty } from "@/data/roadmap";
+import {
+  CURRICULUM,
+  type Category,
+  type Difficulty,
+  type EstimatedMinutes,
+} from "@/data/roadmap";
 import { slugifyStr } from "./slugify";
 
 export interface RoadmapEntry {
@@ -6,6 +11,8 @@ export interface RoadmapEntry {
   slug: string;
   title: string;
   difficulty: Difficulty;
+  category: Category;
+  estimatedMinutes: EstimatedMinutes;
   /** Global challenge number (1-indexed across the whole curriculum) */
   number: number;
   chapterIndex: number;
@@ -36,6 +43,8 @@ for (const [ci, chapter] of CURRICULUM.entries()) {
       slug: challenge.walkthroughSlug,
       title: challenge.title,
       difficulty: challenge.difficulty,
+      category: challenge.category,
+      estimatedMinutes: challenge.estimatedMinutes,
       number: counter,
       chapterIndex: ci + 1,
       chapterTitle: chapter.title,


### PR DESCRIPTION
## Description

Adds a machine-readable challenge feed to the documentation site, and fixes the "Edit page" links that pointed at a branch that does not exist.

**`challenges.json` feed** — a new Astro endpoint (`docs/src/pages/challenges.json.ts`) builds to `https://koadt.github.io/oss-oopssec-store/challenges.json`, following the same static-endpoint pattern as `rss.xml.ts` and `robots.txt.ts`. It exposes the whole curriculum — challenge number, title, difficulty, chapter, prerequisites and resolved walkthrough URL — so external consumers can surface challenges without scraping the site.

The feed is **generated from `docs/src/data/roadmap.ts` at build time**, so it stays in sync automatically: adding a challenge to the curriculum is still a single-file edit, exactly as before. The payload shape is documented by the exported TypeScript interfaces in the endpoint, and carries a `version` field to bump on any breaking change.

Two supporting details:

- Walkthrough URLs are resolved through the content collection and `getPath`, never from filenames. A post's id can be overridden by a `slug:` frontmatter field (as `insecure-password-reset-writeup.md` does), so filename-derived URLs would be wrong.
- `postFilter` is applied, so a draft or scheduled walkthrough is emitted as `"walkthrough": null` instead of a dead link. The field is typed nullable to force consumers to handle it.

**Anchor helpers** — `chapterAnchorId` / `challengeAnchorId` / `formatRoadmapNumber` now live in `docs/src/utils/getRoadmapContext.ts`, alongside a new `getChallenges()` that exposes the already-computed flat curriculum. The roadmap page uses them instead of a local `pad` helper. Without this the `#challenge-07` anchor format was defined in two places, and the feed could have pointed at dead anchors the day the padding changed.

**Edit page fix** — `SITE.editPost.url` referenced `edit/develop/`, but the repository has no `develop` branch (`origin/HEAD → main`). Every published walkthrough therefore had a broken "Edit page" button, silently discouraging community fixes on a project that welcomes them.

No changes to the vulnerable application itself: this touches `docs/` only.

## Type of change

- [x] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [ ] Documentation update
- [x] Other (please describe): machine-readable challenge feed published by the docs site

## Testing done

Ran the exact gates from `deploy-docs.yml`, all passing:

- `npm run lint`
- `npm run format:check`
- `npm run build` (includes `astro check`) — 111 pages built, no errors or warnings

Verified the generated `dist/challenges.json`:

- 35 challenges in curriculum order, matching `TOTAL_CHALLENGES`
- difficulty split 6 EASY / 19 MEDIUM / 10 HARD, matching `CHALLENGES_BY_DIFFICULTY`
- every challenge resolves a walkthrough (`walkthrough: null` count is 0)
- `insecure-password-reset` resolves to `/posts/insecure-password-reset`, confirming the frontmatter-slug case is handled
- prerequisites preserved (e.g. challenge 16 → `[14, 15]`)

Regression check on the roadmap page after the anchor refactor, against the built HTML:

- all 35 `id="challenge-NN"` anchors present
- all 11 chapter anchors present
- "Builds on" prerequisite links still resolve (`#challenge-14`, `#challenge-15`, …)

Edit page fix verified against the live repository:

- `blob/main/docs/src/data/blog/insecure-password-reset-writeup.md` → **200**
- `blob/develop/docs/src/data/blog/insecure-password-reset-writeup.md` → **404**

## Checklist

- [x] Documentation updated (if applicable) — the feed contract is documented by the exported TypeScript interfaces in `challenges.json.ts`

### If adding a new vulnerability

_Not applicable — no new vulnerability, flag, or walkthrough in this PR._

- [ ] Flag added in `prisma/seed.ts` with format `OSS{...}`
- [ ] Three progressive hints added in `prisma/seed.ts`
- [ ] Vulnerable code path is exploitable and demonstrable
- [ ] Reference doc added under `content/vulnerabilities/` (concept + fix only — no exploit steps, payloads, or flag value)
- [ ] Regression tests added (unit, API, and/or E2E)
- [ ] No real-world secrets introduced
- [ ] If a walkthrough was also added under `docs/src/data/blog/`, `walkthroughSlug` is set on the flag in `prisma/seed.ts`
