### PR TITLE
docs: require Node 20 in educator setup

### DIFF
--- a/EDUCATORS.md
+++ b/EDUCATORS.md
@@ -234,7 +234,7 @@ Recommended setup for classrooms: each student runs the app on their own machine
 
 | Setup      | Requirements                     |
 | ---------- | -------------------------------- |
-| Node.js    | Node 18+, npm                    |
+| Node.js    | Node 20+, npm                    |
 | Docker     | Docker Desktop or Docker Engine  |
 | Disk space | ~500 MB                          |
 | RAM        | 512 MB minimum, 1 GB recommended |


### PR DESCRIPTION
## Description

Update the classroom system-requirements table to match the Node.js 20 minimum declared by both package manifests.

Closes #267

AI assistance: OpenAI Codex was used to verify the package-engine requirements, apply the documentation correction, and run validation.

## Type of change

- [x] Documentation update

## Testing done

- confirmed `engines.node` is `>=20.0.0` in both package manifests
- confirmed `Node 18` no longer appears in `EDUCATORS.md`, `README.md`, or `CONTRIBUTING.md`
- `git diff --check`

## Checklist

- [x] Documentation updated