### PR TITLE
docs: bind Docker examples to localhost

### DIFF
--- a/EDUCATORS.md
+++ b/EDUCATORS.md
@@ -13,7 +13,7 @@ cd my-lab && npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Point your students to the [Roadmap](https://koadt.github.io/oss-oopssec-store/roadmap) as their entry point. It lays out all 36 challenges in a visual learning path, with chapters ordered from easy to hard, and recommends a self-guided approach (try the challenge first, then read the walkthrough).
@@ -205,7 +205,7 @@ Yes. Both the local Node.js and Docker setups are fully self-contained. No exter
 docker pull leogra/oss-oopssec-store
 
 # Students run locally with no internet
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 ### Can multiple students share one instance?

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Hunt for flags, exploit vulnerabilities, and level up your security skills.
 npx create-oss-store my-ctf-lab && cd my-ctf-lab && npm start
 
 # Docker
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 
 # Then open http://localhost:3000 and start hacking
 ```
@@ -130,16 +130,18 @@ This creates the `.env` file, installs dependencies, sets up the SQLite database
 
 No Node.js required. Just [Docker](https://docs.docker.com/get-docker/).
 
+> `127.0.0.1:3000:3000` keeps the lab reachable only from your own machine. Use plain `-p 3000:3000` only on an isolated VM you control.
+
 #### From Docker Hub (quickest)
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 To persist data across restarts:
 
 ```bash
-docker run -p 3000:3000 -v oss-data:/app/data leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 -v oss-data:/app/data leogra/oss-oopssec-store
 ```
 
 #### From source (Docker Compose)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   app:
     build: .
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     env_file:
       - path: .env.local
         required: false

--- a/docs/src/data/blog/aes-cbc-padding-oracle-forged-share-token.md
+++ b/docs/src/data/blog/aes-cbc-padding-oracle-forged-share-token.md
@@ -32,7 +32,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/bola-wishlist-access.md
+++ b/docs/src/data/blog/bola-wishlist-access.md
@@ -31,7 +31,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/brute-force-no-rate-limiting.md
+++ b/docs/src/data/blog/brute-force-no-rate-limiting.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/client-side-price-manipulation.md
+++ b/docs/src/data/blog/client-side-price-manipulation.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/csrf-admin-order-update.md
+++ b/docs/src/data/blog/csrf-admin-order-update.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The application runs at `http://localhost:3000`.

--- a/docs/src/data/blog/idor-order-privacy-breach.md
+++ b/docs/src/data/blog/idor-order-privacy-breach.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The application runs at `http://localhost:3000`.

--- a/docs/src/data/blog/information-disclosure-api-error.md
+++ b/docs/src/data/blog/information-disclosure-api-error.md
@@ -29,7 +29,7 @@ npx create-oss-store@latest
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/insecure-password-reset-writeup.md
+++ b/docs/src/data/blog/insecure-password-reset-writeup.md
@@ -28,7 +28,7 @@ npx create-oss-store@latest
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/insecure-randomness-gift-card.md
+++ b/docs/src/data/blog/insecure-randomness-gift-card.md
@@ -35,7 +35,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`. Two demo accounts are relevant:

--- a/docs/src/data/blog/jwt-algorithm-confusion-partner-api.md
+++ b/docs/src/data/blog/jwt-algorithm-confusion-partner-api.md
@@ -35,7 +35,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/jwt-weak-secret-admin-bypass.md
+++ b/docs/src/data/blog/jwt-weak-secret-admin-bypass.md
@@ -31,7 +31,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Head to `http://localhost:3000` and log in with the test credentials shown on the login page. Use Alice's account -- she's a regular customer.

--- a/docs/src/data/blog/live-stream-hijack.md
+++ b/docs/src/data/blog/live-stream-hijack.md
@@ -33,7 +33,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/malicious-file-upload-stored-xss.md
+++ b/docs/src/data/blog/malicious-file-upload-stored-xss.md
@@ -40,7 +40,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Once it's up, go to `http://localhost:3000` and log in with the admin credentials you recovered.

--- a/docs/src/data/blog/mass-assignment-admin-privilege-escalation.md
+++ b/docs/src/data/blog/mass-assignment-admin-privilege-escalation.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/mcp-malicious-server.md
+++ b/docs/src/data/blog/mcp-malicious-server.md
@@ -33,7 +33,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The AI assistant lives at `http://localhost:3000/support/ai-assistant` and needs a Mistral AI API key.

--- a/docs/src/data/blog/middleware-authorization-bypass-cve-2025-29927.md
+++ b/docs/src/data/blog/middleware-authorization-bypass-cve-2025-29927.md
@@ -32,7 +32,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Head to `http://localhost:3000`.

--- a/docs/src/data/blog/next-public-env-variable-leak.md
+++ b/docs/src/data/blog/next-public-env-variable-leak.md
@@ -31,7 +31,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The application runs at `http://localhost:3000`.

--- a/docs/src/data/blog/open-redirect-login-bypass.md
+++ b/docs/src/data/blog/open-redirect-login-bypass.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The application runs at `http://localhost:3000`.

--- a/docs/src/data/blog/path-traversal-documents-api.md
+++ b/docs/src/data/blog/path-traversal-documents-api.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Head to `http://localhost:3000`.

--- a/docs/src/data/blog/plaintext-password-in-logs.md
+++ b/docs/src/data/blog/plaintext-password-in-logs.md
@@ -31,7 +31,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/product-search-sql-injection.md
+++ b/docs/src/data/blog/product-search-sql-injection.md
@@ -40,7 +40,7 @@ npm run dev
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/prompt-injection-ai-assistant.md
+++ b/docs/src/data/blog/prompt-injection-ai-assistant.md
@@ -32,7 +32,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The AI assistant lives at `http://localhost:3000/support/ai-assistant` and needs a Mistral AI API key.

--- a/docs/src/data/blog/race-condition-coupon-abuse.md
+++ b/docs/src/data/blog/race-condition-coupon-abuse.md
@@ -32,7 +32,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/react2shell-cve-2025-55182.md
+++ b/docs/src/data/blog/react2shell-cve-2025-55182.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Head to `http://localhost:3000` and make sure the app loads.

--- a/docs/src/data/blog/second-order-sql-injection.md
+++ b/docs/src/data/blog/second-order-sql-injection.md
@@ -31,7 +31,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/self-xss-csrf-profile-takeover.md
+++ b/docs/src/data/blog/self-xss-csrf-profile-takeover.md
@@ -42,7 +42,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/session-fixation-weak-session-management.md
+++ b/docs/src/data/blog/session-fixation-weak-session-management.md
@@ -31,7 +31,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Head to `http://localhost:3000`.

--- a/docs/src/data/blog/sql-injection-writeup.md
+++ b/docs/src/data/blog/sql-injection-writeup.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Head to `http://localhost:3000`.

--- a/docs/src/data/blog/ssrf-internal-page-access.md
+++ b/docs/src/data/blog/ssrf-internal-page-access.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Head to `http://localhost:3000`.

--- a/docs/src/data/blog/stored-xss-product-reviews.md
+++ b/docs/src/data/blog/stored-xss-product-reviews.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/supply-chain-poisoned-rules-chain.md
+++ b/docs/src/data/blog/supply-chain-poisoned-rules-chain.md
@@ -37,7 +37,7 @@ npm start
 Or with Docker:
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 ## Threat model

--- a/docs/src/data/blog/weak-md5-hashing-admin-compromise.md
+++ b/docs/src/data/blog/weak-md5-hashing-admin-compromise.md
@@ -30,7 +30,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/x-forwarded-for-sql-injection.md
+++ b/docs/src/data/blog/x-forwarded-for-sql-injection.md
@@ -31,7 +31,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 The app runs at `http://localhost:3000`.

--- a/docs/src/data/blog/xxe-supplier-order-import.md
+++ b/docs/src/data/blog/xxe-supplier-order-import.md
@@ -31,7 +31,7 @@ npm start
 Or with Docker (no Node.js required):
 
 ```bash
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Head to `http://localhost:3000`.

--- a/docs/src/pages/about.md
+++ b/docs/src/pages/about.md
@@ -27,7 +27,7 @@ The goal is simple: hunt for hidden flags, exploit vulnerabilities, and level up
 npx create-oss-store && cd oss-oopssec-store && npm start
 
 # With Docker
-docker run -p 3000:3000 leogra/oss-oopssec-store
+docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) and start hunting flags.

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -58,7 +58,7 @@ const sortedPosts = getSortedPosts(posts);
           code={`# With Node.js
 $ npx create-oss-store && cd oss-oopssec-store && npm start
 # With Docker
-$ docker run -p 3000:3000 leogra/oss-oopssec-store
+$ docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store
 
 # → Open http://localhost:3000 and start hacking`}
           lang="bash"


### PR DESCRIPTION
## Description

Closes #268

Binds Docker and Compose examples to `127.0.0.1` so the intentionally vulnerable lab is not exposed to the local network by default. Updates every published walkthrough command and documents when the LAN-wide binding is appropriate.

## Type of change

- [ ] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [x] Documentation update
- [ ] Other (please describe):

## Testing done

- [x] `npm run docs:lint`
- [x] `npm run docs:format:check`
- [x] `npm run docs:build`
- [x] `docker compose config --quiet`
- [x] Confirmed `docker run -p 3000` no longer appears in the published docs

## Checklist

- [x] Documentation updated (if applicable)

The new-challenge checklist is not applicable; this PR does not add or modify a challenge.