### PR TITLE
fix: handle newsletter submissions

### DIFF
--- a/app/components/Newsletter.tsx
+++ b/app/components/Newsletter.tsx
@@ -1,4 +1,15 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+
 export default function Newsletter() {
+  const [subscribed, setSubscribed] = useState(false);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubscribed(true);
+  };
+
   return (
     <section className="bg-gradient-to-r from-primary-500 to-secondary-500 py-16">
       <div className="container mx-auto px-4">
@@ -10,7 +21,10 @@ export default function Newsletter() {
             Subscribe to our newsletter and get exclusive offers, new product
             announcements, and special discounts delivered to your inbox.
           </p>
-          <form className="flex flex-col gap-4 sm:flex-row sm:justify-center">
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-4 sm:flex-row sm:justify-center"
+          >
             <input
               type="email"
               placeholder="Enter your email"
@@ -24,6 +38,13 @@ export default function Newsletter() {
               Subscribe
             </button>
           </form>
+          <div role="status" aria-live="polite">
+            {subscribed && (
+              <p className="mt-4 text-base font-medium text-white">
+                Thanks for subscribing.
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Description

Closes #58.

The newsletter form now prevents the default page submission and shows an inline success message. The status uses `aria-live="polite"`; no API route, persistence, or dependency was added.

![Newsletter success message after submission](https://raw.githubusercontent.com/prashantbhudwal/oss-oopssec-store/pr-assets/2026-08-15-ui-fixes/.github/pr-assets/2026-08-15-ui-fixes/issue-58-newsletter-success.png)

## Type of change

- [x] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [ ] Documentation update
- [ ] Other

## Testing done

- `npm run format:check`
- `npm run lint` (0 errors; 15 existing warnings)
- `npm run build`
- `npm run test:unit` (97 passed; 4 skipped)
- In-app browser: submitted `ui-test@example.com`, confirmed the URL stayed at `/`, and checked that the success message appeared

## Checklist

- [ ] Documentation updated (not applicable for this component-only change)

### If adding a new challenge

Not applicable.
