### PR TITLE
test: turn the react2shell suite into a real exploit canary

### DIFF
--- a/EDUCATORS.md
+++ b/EDUCATORS.md
@@ -34,7 +34,7 @@ Point your students to the [Roadmap](https://koadt.github.io/oss-oopssec-store/r
 
 ## Why OopsSec Store?
 
-OopsSec Store is the only intentionally vulnerable web application built with **Next.js and React**: the stack your students will actually encounter in production. It also treats the AI-era attack surface — prompt injection, MCP tool poisoning, AI coding-agent backdoors, supply-chain attack chains — as first-class challenges, not add-ons.
+An intentionally vulnerable web application built with **Next.js and React**: the stack your students will actually encounter in production. It also treats the AI-era attack surface — prompt injection, MCP tool poisoning, AI coding-agent backdoors, supply-chain attack chains — as first-class challenges, not add-ons.
 
 For a feature-by-feature comparison with Juice Shop and DVWA, see the [comparison table in the README](https://github.com/kOaDT/oss-oopssec-store#why-oopssec-store).
 

--- a/tests/api/react2shell.test.ts
+++ b/tests/api/react2shell.test.ts
@@ -1,7 +1,44 @@
-import { apiRequest } from "../helpers/api";
+import { apiRequest, BASE_URL } from "../helpers/api";
 import { FLAGS } from "../helpers/flags";
 
+/**
+ * The RCE itself is never fired in CI. This suite checks that the running
+ * server still exposes what the exploit needs — a Flight endpoint that serves
+ * client references, and a Server Action pipeline that deserializes a
+ * client-supplied reference id before it validates it — while
+ * tests/unit/react2shell-flight-deserializer.test.ts covers the unguarded
+ * prototype-chain lookups those references are resolved with.
+ */
+
+const CLIENT_REFERENCE_ROW = /^\d+:I\[.*\]$/m;
+const UNVALIDATED_REFERENCE_ID = "reference-that-no-manifest-declares";
+
+async function postForm(fields: Record<string, string>): Promise<number> {
+  const body = new FormData();
+  for (const [name, value] of Object.entries(fields)) {
+    body.append(name, value);
+  }
+
+  const response = await fetch(BASE_URL, { method: "POST", body });
+  return response.status;
+}
+
 describe("React 19 RCE (CVE-2025-55182) – react2shell", () => {
+  it("serves client references over the Flight protocol", async () => {
+    const response = await fetch(BASE_URL, { headers: { RSC: "1" } });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/x-component");
+    expect(await response.text()).toMatch(CLIENT_REFERENCE_ROW);
+  });
+
+  it("deserializes an unauthenticated Server Action reference id", async () => {
+    expect(await postForm({ plainField: "value" })).toBe(200);
+    expect(
+      await postForm({ [`$ACTION_ID_${UNVALIDATED_REFERENCE_ID}`]: "1" })
+    ).toBe(500);
+  });
+
   it("POST /api/flags/verify returns valid: true for OSS{r3act2sh3ll}", async () => {
     const { status, data } = await apiRequest<{ valid: boolean }>(
       "/api/flags/verify",

--- a/tests/unit/react2shell-config.test.ts
+++ b/tests/unit/react2shell-config.test.ts
@@ -2,21 +2,28 @@ import * as fs from "fs";
 import * as path from "path";
 import { FLAGS } from "../helpers/flags";
 
+/**
+ * The pins that keep the challenge reproducible. What actually proves the
+ * deserializer is still exploitable lives in
+ * tests/unit/react2shell-flight-deserializer.test.ts.
+ */
+
+const AFFECTED_REACT_VERSION = "19.2.0";
 const FLAG_ENV_VAR = "FLAG_CVE_2025_55182";
 
 describe("React 19 RCE (CVE-2025-55182) – Configuration", () => {
-  it("dependencies.react is 19.2.0 or matches ^19", () => {
+  it("pins react and react-dom to an affected version", () => {
     const pkgPath = path.join(process.cwd(), "package.json");
     expect(fs.existsSync(pkgPath)).toBe(true);
 
     const content = fs.readFileSync(pkgPath, "utf-8");
-    const pkg = JSON.parse(content) as { dependencies?: { react?: string } };
+    const pkg = JSON.parse(content) as {
+      dependencies?: Record<string, string>;
+    };
     expect(pkg.dependencies).toBeDefined();
-    expect(pkg.dependencies!.react).toBeDefined();
 
-    const reactVersion = pkg.dependencies!.react as string;
-    expect(reactVersion).toBe("19.2.0");
-    expect(reactVersion.startsWith("19")).toBe(true);
+    expect(pkg.dependencies!.react).toBe(AFFECTED_REACT_VERSION);
+    expect(pkg.dependencies!["react-dom"]).toBe(AFFECTED_REACT_VERSION);
   });
 
   it('.env.local contains FLAG_CVE_2025_55182="OSS{r3act2sh3ll}"', () => {

--- a/tests/unit/react2shell-flight-deserializer.test.ts
+++ b/tests/unit/react2shell-flight-deserializer.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment-options {"customExportConditions": ["react-server", "node", "node-addons"]}
+ */
+
+/**
+ * CVE-2025-55182 lives inside React's Flight deserializer, not in this
+ * codebase, so there is no vulnerable route of our own to exercise. This suite
+ * is the canary in its place: it drives the deserializer Next actually ships
+ * and asserts that the two prototype-chain lookups the exploit chains together
+ * are still unguarded.
+ *
+ *   1. `bundlerConfig[id]`            — resolves a module id off the manifest
+ *   2. `moduleExports[metadata[2]]`   — resolves an export name off that module
+ *
+ * Both take a client-controlled key and walk the prototype chain, which is what
+ * hands the exploit `Function` and, from there, code execution. The probes below
+ * stop one hop short of that: the reference they resolve is an inert `Object`
+ * constructor and is never called. Upgrading React — or upgrading Next to a
+ * release bundling a patched React — makes those lookups miss and fails here.
+ */
+
+type ServerReference = ((...args: unknown[]) => unknown) | null;
+
+type ServerManifest = Record<
+  string,
+  { id: string; chunks: string[]; name: string }
+>;
+
+interface FlightServer {
+  decodeAction(
+    body: FormData,
+    serverManifest: ServerManifest
+  ): Promise<ServerReference>;
+}
+
+const FLIGHT_SERVERS = {
+  webpack:
+    "next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js",
+  turbopack:
+    "next/dist/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js",
+} as const;
+
+const STUB_MODULE_ID = "stub-module";
+const DECLARED_EXPORT = "declaredAction";
+const INHERITED_PROPERTY = "constructor";
+const UNDECLARED_MODULE_ID = "no-such-module";
+const MANIFEST_MISS = /in the React Server Manifest/;
+
+const MANIFEST: ServerManifest = {
+  [STUB_MODULE_ID]: { id: STUB_MODULE_ID, chunks: [], name: DECLARED_EXPORT },
+};
+
+beforeAll(() => {
+  (
+    globalThis as unknown as { __next_require__: (id: string) => unknown }
+  ).__next_require__ = () => ({
+    [DECLARED_EXPORT]: function declaredAction() {},
+  });
+});
+
+/**
+ * Feeds the deserializer the `$ACTION_ID_<id>` field a Server Action request
+ * carries, with `id` fully client-controlled — exactly what React2Shell abuses.
+ * `async` so that a synchronous throw inside `decodeAction` surfaces as a
+ * rejection like any other failure.
+ */
+async function decodeActionReference(
+  flight: FlightServer,
+  referenceId: string
+): Promise<ServerReference> {
+  const body = new FormData();
+  body.append(`$ACTION_ID_${referenceId}`, "1");
+  return flight.decodeAction(body, MANIFEST);
+}
+
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+    return "";
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+describe.each(Object.entries(FLIGHT_SERVERS))(
+  "React 19 RCE (CVE-2025-55182) – %s Flight deserializer",
+  (_bundler, modulePath) => {
+    const flight = require(modulePath) as FlightServer;
+
+    it("resolves a reference the manifest declares", async () => {
+      const action = await decodeActionReference(
+        flight,
+        `${STUB_MODULE_ID}#${DECLARED_EXPORT}`
+      );
+
+      expect(action).toBeInstanceOf(Function);
+      expect(action!.name).toBe(`bound ${DECLARED_EXPORT}`);
+    });
+
+    it("rejects a module id the manifest does not declare", async () => {
+      await expect(
+        decodeActionReference(flight, UNDECLARED_MODULE_ID)
+      ).rejects.toThrow(MANIFEST_MISS);
+    });
+
+    it("resolves an inherited property as a module id", async () => {
+      const message = await rejectionMessage(
+        decodeActionReference(flight, INHERITED_PROPERTY)
+      );
+
+      expect(message).not.toMatch(MANIFEST_MISS);
+    });
+
+    it("resolves an inherited property as an export name", async () => {
+      const action = await decodeActionReference(
+        flight,
+        `${STUB_MODULE_ID}#${INHERITED_PROPERTY}`
+      );
+
+      expect(action).toBeInstanceOf(Function);
+      expect(action!.name).toBe(`bound ${Object.name}`);
+    });
+  }
+);


### PR DESCRIPTION
## Description

`README.md` claimed *"Automated tests that verify exploits still work (PRs that accidentally fix a vuln will fail CI)"*. That held for 35 of the 36 challenges, but not for react2shell: `tests/api/react2shell.test.ts` only replayed the known flag against `/api/flags/verify` (green on any database seeded from `prisma/flags.ts`, vulnerability or not), and `tests/unit/react2shell-config.test.ts` asserted a version string as a proxy for exploitability.

This strengthens the tests until the claim holds, rather than watering the claim down.

CVE-2025-55182 is two unguarded prototype-chain lookups in React's Flight deserializer, chained:

1. `bundlerConfig[id]` in `resolveServerReference` — resolves a client-supplied module id
2. `moduleExports[metadata[2]]` in `requireModule` — resolves a client-supplied export name

**New:** `tests/unit/react2shell-flight-deserializer.test.ts` drives the deserializer Next actually ships (the webpack **and** turbopack `server.node.production` bundles under `next/dist/compiled/`) through its public `decodeAction` entry point, feeding it the `$ACTION_ID_<id>` field a Server Action request carries. Four probes per bundler:

- `stub-module#declaredAction` resolves — control, the harness is wired correctly
- `no-such-module` throws *"Could not find the module … in the React Server Manifest"* — control, undeclared ids miss
- `constructor` does **not** throw that error → lookup 1 walks the prototype chain
- `stub-module#constructor` resolves to `bound Object` → lookup 2 walks it too

The resolved reference is an inert `Object` constructor and is never called — no `Function`, no payload, no code execution. Loading the react-server build needs the `react-server` export condition, handled with a per-file `@jest-environment-options` docblock, so no global Jest config change.

**Changed:**

- `tests/api/react2shell.test.ts` — no longer a tautology. Asserts the server still serves Flight client references (`RSC: 1` → `text/x-component` with `N:I[…]` rows) and that an unauthenticated action-shaped multipart POST reaches the deserializer before any id validation (plain field → 200, `$ACTION_ID_…` → 500). The flag check stays, as one test among three.
- `tests/unit/react2shell-config.test.ts` — dropped a redundant `startsWith("19")` assertion, pins `react` **and** `react-dom`, points at the canary.
- `README.md` — one paragraph in Testing: React2Shell is the one exploit CI never fires, and here is what its tests do instead.
- `CONTRIBUTING.md` — one line telling contributors to assert the vulnerable primitive when the flaw lives in a dependency.

`EDUCATORS.md` needed no change — it never makes the CI claim (its only mention is "regression tests" in the contribution checklist).

**Worth knowing:** the RSC deserializer that actually runs is Next's *vendored* React (`next/dist/compiled/react-server-dom-*`, built from a 19.1.0 canary), not the `react@19.2.0` in `dependencies`. Bumping `react` alone is caught by the version pin; bumping `next` to a release with a patched React is caught by the canary. Both realistic "accidental fix" paths now fail CI.

Out of scope, deliberately: executing CVE-2025-55182 in CI, removing the challenge, unpinning React.

## Type of change

- [ ] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [x] Documentation update
- [x] Other (please describe): regression-test hardening — turns the react2shell suite into a canary that fails when the vulnerability is patched

## Testing done

- **Fails on a patch (the point of the change):** patched the vendored webpack bundle in place with `hasOwnProperty` guards on both lookups — what a fixed React does — reran, got exactly the 2 expected failures with both controls still green, then restored the file.
- `npm run test:unit` — 132 passing (1 suite skipped: Mistral, no API key locally).
- `npm run test:api` — 269 passing, run twice: against a production build (`npm run build && npm run start`, what CI does) and against `npm run dev` (turbopack), since the two runtimes load different Flight bundles.
- Prettier and ESLint clean on every touched file.

## Checklist

- [x] Documentation updated (if applicable)

### If adding a new challenge

_Not applicable — no new challenge, flag, or vulnerable code path. `prisma/flags.ts`, `content/vulnerabilities/`, the roadmap and the counts are untouched._
