### PR TITLE
fix: add accessible name to newsletter email input (#295)

### DIFF
--- a/app/components/Newsletter.tsx
+++ b/app/components/Newsletter.tsx
@@ -28,6 +28,7 @@ export default function Newsletter() {
             <input
               type="email"
               placeholder="Enter your email"
+              aria-label="Email address"
               className="w-full flex-1 rounded-full border-0 bg-white px-6 py-4 text-base text-slate-900 placeholder-slate-400 shadow-lg backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-primary-500 sm:max-w-md"
               required
             />


### PR DESCRIPTION
## What changed
Added `aria-label="Email address"` to the newsletter email `<input>` in `app/components/Newsletter.tsx`.

## Why
The input previously had only a `placeholder`, which is not a valid accessible name and disappears as soon as the user types. Screen readers had no label for the field. This resolves issue #295.

## Scope
- One-line accessibility fix; no behavior or styling change.
- Does NOT touch any intentional vulnerability (per AGENTS.md / CTF scope).

## Verification
- `input` now exposes an accessible name via `aria-label`.
- No layout/snapshot churn.

Resolves #295