### PR TITLE
fix: add accessible name to modal close buttons (#294)

### DIFF
--- a/app/components/FlagChecker.tsx
+++ b/app/components/FlagChecker.tsx
@@ -316,6 +316,7 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
               </h2>
               <button
                 onClick={closeChecker}
+                aria-label="Close"
                 className="cursor-pointer text-slate-400 transition-colors hover:text-slate-600 dark:hover:text-slate-300"
                 disabled={isVerifying}
               >

--- a/app/components/HintPanel.tsx
+++ b/app/components/HintPanel.tsx
@@ -103,6 +103,7 @@ export default function HintPanel({ initialState }: HintPanelProps) {
               </h2>
               <button
                 onClick={() => setIsOpen(false)}
+                aria-label="Close"
                 className="cursor-pointer text-slate-400 transition-colors hover:text-slate-600 dark:hover:text-slate-300"
               >
                 <svg


### PR DESCRIPTION
## What changed
Added `aria-label="Close"` to the two icon-only modal close buttons in `app/components/FlagChecker.tsx` and `app/components/HintPanel.tsx`.

## Why
The buttons render an SVG cross with no text and no accessible name, so screen readers announced them only as "button". This resolves issue #294.

## Scope
- Accessibility fix only; no behavior or styling change.
- Does not touch any intentional vulnerability (per AGENTS.md / CTF scope).

## Verification
- Both close buttons now expose an accessible name via `aria-label`.

Resolves #294