### PR TITLE
fix: render npm slug as lowercase in titles (#293)

### DIFF
--- a/lib/format.ts
+++ b/lib/format.ts
@@ -2,6 +2,7 @@ import type { FlagCategory } from "@/lib/types";
 
 const TITLE_OVERRIDES: Record<string, string> = {
   CVE: "CVE",
+  NPM: "npm",
   SQL: "SQL",
   XSS: "XSS",
   CSRF: "CSRF",


### PR DESCRIPTION
## What changed
Added `NPM: "npm"` to `TITLE_OVERRIDES` in `lib/format.ts`.

## Why
The slug `npm-supply-chain-typosquat` rendered as "Npm Supply Chain Typosquat" because `npm` was missing from the override map. This resolves issue #293.

## Scope
- One-line title-format fix; no behavior change.
- Does not touch any intentional vulnerability (per AGENTS.md / CTF scope).

Resolves #293