### PR TITLE
fix: use shared formatSlug

### DIFF
--- a/app/components/FlagChecker.tsx
+++ b/app/components/FlagChecker.tsx
@@ -7,7 +7,6 @@ import SupportBanner, { shouldShowSupportBanner } from "./SupportBanner";
 import { GITHUB_REPO } from "@/lib/config";
 import { formatSlug } from "@/lib/format";
 
-
 const INITIAL_ANIMATION_DURATION = 10000;
 
 interface FlagCheckerProps {
@@ -237,8 +236,8 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
             style={
               isInitialAnimation
                 ? {
-                    animation: "button-glow 2s ease-in-out infinite",
-                  }
+                  animation: "button-glow 2s ease-in-out infinite",
+                }
                 : undefined
             }
             aria-label="Check flag"
@@ -301,11 +300,10 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
           >
             <div className="mb-4 flex items-center justify-between">
               <h2
-                className={`text-xl font-bold ${
-                  allFlagsFound
+                className={`text-xl font-bold ${allFlagsFound
                     ? "text-yellow-600 dark:text-yellow-400"
                     : "text-slate-900 dark:text-slate-100"
-                }`}
+                  }`}
               >
                 {allFlagsFound ? "All Flags Found" : "Verify Flag"}
               </h2>
@@ -354,15 +352,14 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
 
             {message && (
               <div
-                className={`mb-4 rounded-lg p-3 text-sm ${
-                  message.includes("all flags")
+                className={`mb-4 rounded-lg p-3 text-sm ${message.includes("all flags")
                     ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
                     : message.includes("Congrats")
                       ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
                       : message.includes("already found")
                         ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400"
                         : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400"
-                }`}
+                  }`}
               >
                 {message}
               </div>
@@ -459,11 +456,10 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
 
             <div className="flex items-center justify-between">
               <p
-                className={`text-sm ${
-                  allFlagsFound
+                className={`text-sm ${allFlagsFound
                     ? "text-yellow-600 dark:text-yellow-400"
                     : "text-slate-600 dark:text-slate-400"
-                }`}
+                  }`}
               >
                 {foundFlags.length}/{totalFlags} flags found
                 {allFlagsFound && " ✓"}
@@ -472,11 +468,10 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
                 <button
                   onClick={handleVerify}
                   disabled={isVerifying || !flagInput.trim()}
-                  className={`rounded-lg cursor-pointer bg-primary-600 px-4 py-2 text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-primary-500 dark:hover:bg-primary-600 ${
-                    highlightVerify
+                  className={`rounded-lg cursor-pointer bg-primary-600 px-4 py-2 text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-primary-500 dark:hover:bg-primary-600 ${highlightVerify
                       ? "ring-2 ring-primary-400 ring-offset-2"
                       : ""
-                  }`}
+                    }`}
                 >
                   {isVerifying ? "Verifying..." : "Verify"}
                 </button>

--- a/app/components/FlagChecker.tsx
+++ b/app/components/FlagChecker.tsx
@@ -7,6 +7,7 @@ import SupportBanner, { shouldShowSupportBanner } from "./SupportBanner";
 import { GITHUB_REPO } from "@/lib/config";
 import { formatSlug } from "@/lib/format";
 
+
 const INITIAL_ANIMATION_DURATION = 10000;
 
 interface FlagCheckerProps {
@@ -236,8 +237,8 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
             style={
               isInitialAnimation
                 ? {
-                  animation: "button-glow 2s ease-in-out infinite",
-                }
+                    animation: "button-glow 2s ease-in-out infinite",
+                  }
                 : undefined
             }
             aria-label="Check flag"
@@ -300,10 +301,11 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
           >
             <div className="mb-4 flex items-center justify-between">
               <h2
-                className={`text-xl font-bold ${allFlagsFound
+                className={`text-xl font-bold ${
+                  allFlagsFound
                     ? "text-yellow-600 dark:text-yellow-400"
                     : "text-slate-900 dark:text-slate-100"
-                  }`}
+                }`}
               >
                 {allFlagsFound ? "All Flags Found" : "Verify Flag"}
               </h2>
@@ -352,14 +354,15 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
 
             {message && (
               <div
-                className={`mb-4 rounded-lg p-3 text-sm ${message.includes("all flags")
+                className={`mb-4 rounded-lg p-3 text-sm ${
+                  message.includes("all flags")
                     ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
                     : message.includes("Congrats")
                       ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
                       : message.includes("already found")
                         ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400"
                         : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400"
-                  }`}
+                }`}
               >
                 {message}
               </div>
@@ -456,10 +459,11 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
 
             <div className="flex items-center justify-between">
               <p
-                className={`text-sm ${allFlagsFound
+                className={`text-sm ${
+                  allFlagsFound
                     ? "text-yellow-600 dark:text-yellow-400"
                     : "text-slate-600 dark:text-slate-400"
-                  }`}
+                }`}
               >
                 {foundFlags.length}/{totalFlags} flags found
                 {allFlagsFound && " ✓"}
@@ -468,10 +472,11 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
                 <button
                   onClick={handleVerify}
                   disabled={isVerifying || !flagInput.trim()}
-                  className={`rounded-lg cursor-pointer bg-primary-600 px-4 py-2 text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-primary-500 dark:hover:bg-primary-600 ${highlightVerify
+                  className={`rounded-lg cursor-pointer bg-primary-600 px-4 py-2 text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-primary-500 dark:hover:bg-primary-600 ${
+                    highlightVerify
                       ? "ring-2 ring-primary-400 ring-offset-2"
                       : ""
-                    }`}
+                  }`}
                 >
                   {isVerifying ? "Verifying..." : "Verify"}
                 </button>

--- a/app/components/FlagChecker.tsx
+++ b/app/components/FlagChecker.tsx
@@ -7,7 +7,6 @@ import SupportBanner, { shouldShowSupportBanner } from "./SupportBanner";
 import { GITHUB_REPO } from "@/lib/config";
 import { formatSlug } from "@/lib/format";
 
-
 const INITIAL_ANIMATION_DURATION = 10000;
 
 interface FlagCheckerProps {
@@ -397,9 +396,7 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
                             d="M5 13l4 4L19 7"
                           />
                         </svg>
-                        <span className="truncate">
-                          {formatSlug(slug)}
-                        </span>
+                        <span className="truncate">{formatSlug(slug)}</span>
                       </Link>
                     </li>
                   ))}

--- a/app/components/FlagChecker.tsx
+++ b/app/components/FlagChecker.tsx
@@ -5,13 +5,8 @@ import Link from "next/link";
 import confetti from "canvas-confetti";
 import SupportBanner, { shouldShowSupportBanner } from "./SupportBanner";
 import { GITHUB_REPO } from "@/lib/config";
+import { formatSlug } from "@/lib/format";
 
-function formatSlugToTitle(slug: string): string {
-  return slug
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
 
 const INITIAL_ANIMATION_DURATION = 10000;
 
@@ -403,7 +398,7 @@ export default function FlagChecker({ totalFlags }: FlagCheckerProps) {
                           />
                         </svg>
                         <span className="truncate">
-                          {formatSlugToTitle(slug)}
+                          {formatSlug(slug)}
                         </span>
                       </Link>
                     </li>

--- a/app/components/HintPanel.tsx
+++ b/app/components/HintPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import type { HintState, RevealedHint } from "@/lib/types";
 import { formatSlug } from "@/lib/format";
 
+
 const DIFFICULTY_COLORS = {
   EASY: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
   MEDIUM:
@@ -147,10 +148,11 @@ export default function HintPanel({ initialState }: HintPanelProps) {
                             {[1, 2, 3].map((i) => (
                               <div
                                 key={i}
-                                className={`h-1.5 w-3 rounded-full ${i <= hint.level
+                                className={`h-1.5 w-3 rounded-full ${
+                                  i <= hint.level
                                     ? "bg-amber-400 dark:bg-amber-500"
                                     : "bg-amber-200 dark:bg-amber-800"
-                                  }`}
+                                }`}
                               />
                             ))}
                           </div>

--- a/app/components/HintPanel.tsx
+++ b/app/components/HintPanel.tsx
@@ -4,7 +4,6 @@ import { useState, useCallback } from "react";
 import type { HintState, RevealedHint } from "@/lib/types";
 import { formatSlug } from "@/lib/format";
 
-
 const DIFFICULTY_COLORS = {
   EASY: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
   MEDIUM:
@@ -148,11 +147,10 @@ export default function HintPanel({ initialState }: HintPanelProps) {
                             {[1, 2, 3].map((i) => (
                               <div
                                 key={i}
-                                className={`h-1.5 w-3 rounded-full ${
-                                  i <= hint.level
+                                className={`h-1.5 w-3 rounded-full ${i <= hint.level
                                     ? "bg-amber-400 dark:bg-amber-500"
                                     : "bg-amber-200 dark:bg-amber-800"
-                                }`}
+                                  }`}
                               />
                             ))}
                           </div>

--- a/app/components/HintPanel.tsx
+++ b/app/components/HintPanel.tsx
@@ -4,7 +4,6 @@ import { useState, useCallback } from "react";
 import type { HintState, RevealedHint } from "@/lib/types";
 import { formatSlug } from "@/lib/format";
 
-
 const DIFFICULTY_COLORS = {
   EASY: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
   MEDIUM:

--- a/app/components/HintPanel.tsx
+++ b/app/components/HintPanel.tsx
@@ -2,13 +2,8 @@
 
 import { useState, useCallback } from "react";
 import type { HintState, RevealedHint } from "@/lib/types";
+import { formatSlug } from "@/lib/format";
 
-function formatSlugToTitle(slug: string): string {
-  return slug
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
 
 const DIFFICULTY_COLORS = {
   EASY: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
@@ -129,7 +124,7 @@ export default function HintPanel({ initialState }: HintPanelProps) {
               <>
                 <div className="mb-4 flex items-center gap-2">
                   <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                    {formatSlugToTitle(hintState.activeFlag.slug)}
+                    {formatSlug(hintState.activeFlag.slug)}
                   </span>
                   <span
                     className={`rounded-full px-2 py-0.5 text-xs font-medium ${DIFFICULTY_COLORS[hintState.activeFlag.difficulty]}`}

--- a/app/player-dashboard/PlayerDashboardClient.tsx
+++ b/app/player-dashboard/PlayerDashboardClient.tsx
@@ -59,8 +59,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   OTHER: "OTHER",
 };
 
-
-
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
   const minutes = Math.floor(seconds / 60);

--- a/app/player-dashboard/PlayerDashboardClient.tsx
+++ b/app/player-dashboard/PlayerDashboardClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { DOCS_BASE_URL, GITHUB_REPO } from "@/lib/config";
-import { getCveUrl, getCweUrl, getOwaspUrl } from "@/lib/format";
+import { formatSlug, getCveUrl, getCweUrl, getOwaspUrl } from "@/lib/format";
 
 interface FoundFlag {
   slug: string;
@@ -59,12 +59,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   OTHER: "OTHER",
 };
 
-function formatSlug(slug: string): string {
-  return slug
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
+
 
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);

--- a/app/player-dashboard/PlayerDashboardClient.tsx
+++ b/app/player-dashboard/PlayerDashboardClient.tsx
@@ -59,8 +59,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   OTHER: "OTHER",
 };
 
-
-
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
   const minutes = Math.floor(seconds / 60);
@@ -390,7 +388,7 @@ export default function PlayerDashboardClient() {
                 {foundFlags.map((flag, index) => {
                   const timeToFind = initializedAt
                     ? new Date(flag.foundAt).getTime() -
-                      new Date(initializedAt).getTime()
+                    new Date(initializedAt).getTime()
                     : 0;
                   const difficultyConfig =
                     DIFFICULTY_CONFIG[flag.difficulty] ||

--- a/app/player-dashboard/PlayerDashboardClient.tsx
+++ b/app/player-dashboard/PlayerDashboardClient.tsx
@@ -59,6 +59,8 @@ const CATEGORY_LABELS: Record<string, string> = {
   OTHER: "OTHER",
 };
 
+
+
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
   const minutes = Math.floor(seconds / 60);
@@ -388,7 +390,7 @@ export default function PlayerDashboardClient() {
                 {foundFlags.map((flag, index) => {
                   const timeToFind = initializedAt
                     ? new Date(flag.foundAt).getTime() -
-                    new Date(initializedAt).getTime()
+                      new Date(initializedAt).getTime()
                     : 0;
                   const difficultyConfig =
                     DIFFICULTY_CONFIG[flag.difficulty] ||


### PR DESCRIPTION
## Summary

Closes #292

### Changes

1. Removed duplicated `formatSlugToTitle` / `formatSlug` implementations from three components.
2. Updated `FlagChecker`, `HintPanel`, and `PlayerDashboardClient` to use the shared `formatSlug` utility from `@/lib/format`.


No unrelated changes.
