### PR TITLE
fix: clean up after failed process, update package-lock (#307)

### DIFF
--- a/packages/create-oss-store/package-lock.json
+++ b/packages/create-oss-store/package-lock.json
@@ -17,7 +17,7 @@
         "create-oss-store": "bin/create-oss-store.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ansi-regex": {

--- a/packages/create-oss-store/src/index.js
+++ b/packages/create-oss-store/src/index.js
@@ -166,6 +166,20 @@ function runCommand(command, args, cwd) {
 
 function failAndCleanup(error, targetPath) {
   console.error(chalk.red(error.message));
-  rmSync(targetPath, { recursive: true, force: true });
+  try {
+    // rmSync can throw on Windows (EBUSY/EPERM) if a file in node_modules
+    // is locked by antivirus or an editor. Catch it so we exit cleanly
+    // instead of crashing mid-cleanup and leaving a broken project behind.
+    rmSync(targetPath, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 200,
+    });
+  } catch {
+    console.error(
+      chalk.yellow(`Could not remove ${targetPath}, please delete it manually.`)
+    );
+  }
   process.exit(1);
 }

--- a/packages/create-oss-store/src/index.js
+++ b/packages/create-oss-store/src/index.js
@@ -49,10 +49,8 @@ export async function createOssStore(projectName) {
     cloneSpinner.succeed("Repository cloned");
   } catch (error) {
     cloneSpinner.fail("Failed to clone repository");
-    console.error(chalk.red(error.message));
     rmSync(DEGIT_CACHE, { recursive: true, force: true });
-    rmSync(targetPath, { recursive: true, force: true });
-    process.exit(1);
+    failAndCleanup(error, targetPath);
   }
 
   // Create .env file
@@ -64,8 +62,7 @@ export async function createOssStore(projectName) {
     envSpinner.succeed(".env file created");
   } catch (error) {
     envSpinner.fail("Failed to create .env file");
-    console.error(chalk.red(error.message));
-    process.exit(1);
+    failAndCleanup(error, targetPath);
   }
 
   // Install dependencies
@@ -75,8 +72,7 @@ export async function createOssStore(projectName) {
     installSpinner.succeed("Dependencies installed");
   } catch (error) {
     installSpinner.fail("Failed to install dependencies");
-    console.error(chalk.red(error.message));
-    process.exit(1);
+    failAndCleanup(error, targetPath);
   }
 
   // Generate Prisma client
@@ -86,8 +82,7 @@ export async function createOssStore(projectName) {
     prismaSpinner.succeed("Prisma client generated");
   } catch (error) {
     prismaSpinner.fail("Failed to generate Prisma client");
-    console.error(chalk.red(error.message));
-    process.exit(1);
+    failAndCleanup(error, targetPath);
   }
 
   // Push database schema
@@ -97,8 +92,7 @@ export async function createOssStore(projectName) {
     dbSpinner.succeed("Database schema pushed");
   } catch (error) {
     dbSpinner.fail("Failed to push database schema");
-    console.error(chalk.red(error.message));
-    process.exit(1);
+    failAndCleanup(error, targetPath);
   }
 
   // Seed database
@@ -108,8 +102,7 @@ export async function createOssStore(projectName) {
     seedSpinner.succeed("Database seeded");
   } catch (error) {
     seedSpinner.fail("Failed to seed database");
-    console.error(chalk.red(error.message));
-    process.exit(1);
+    failAndCleanup(error, targetPath);
   }
 
   // Build
@@ -119,8 +112,7 @@ export async function createOssStore(projectName) {
     buildSpinner.succeed("Lab is operational");
   } catch (error) {
     buildSpinner.fail("Failed to build lab");
-    console.error(chalk.red(error.message));
-    process.exit(1);
+    failAndCleanup(error, targetPath);
   }
 
   // Success message
@@ -170,4 +162,10 @@ function runCommand(command, args, cwd) {
       reject(error);
     });
   });
+}
+
+function failAndCleanup(error, targetPath) {
+  console.error(chalk.red(error.message));
+  rmSync(targetPath, { recursive: true, force: true });
+  process.exit(1);
 }


### PR DESCRIPTION
## Description

Fixes #307. Post-clone steps (.env creation, npm install, db:generate, db:push, db:seed, build) didn't clean up the target directory on failure only a failed clone did. A user hitting a failure mid-setup was left with a partially scaffolded folder, and re-running the CLI failed immediately with "Directory already exists."

This adds cleanup to every post-clone step by extracting the repeated error-log + `rmSync` + `process.exit(1)` logic into a shared `failAndCleanup` helper. The existing "directory already exists" guard at the top is untouched, so a pre-existing folder is never touched, cleanup only ever runs after a successful clone.

## Type of change

- [x] Bug fix
- [ ] New feature (e-commerce site improvement)
- [ ] New vulnerability / flag
- [ ] Walkthrough / writeup
- [ ] Documentation update
- [ ] Other (please describe):

## Testing done

Ran the CLI end-to-end against a real clone, letting `.env` creation and `npm install` succeed, then deliberately sabotaged the `db:generate` script mid-run to force a failure. Confirmed the target directory was fully removed after the failure, and that a normal successful run still completes and keeps the directory.

## Checklist

- [ ] Documentation updated (if applicable)
