### PR TITLE
fix(create-oss-store): capture stdout in runCommand

### DIFF
--- a/packages/create-oss-store/src/index.js
+++ b/packages/create-oss-store/src/index.js
@@ -1,10 +1,10 @@
-import { spawn } from "child_process";
 import { writeFileSync, existsSync, rmSync } from "fs";
 import { homedir } from "os";
 import { resolve, join } from "path";
 import chalk from "chalk";
 import ora from "ora";
 import degit from "degit";
+import { runCommand } from "./run-command.js";
 
 const REPO = "kOaDT/oss-oopssec-store";
 const DEGIT_CACHE = join(homedir(), ".degit", "github", ...REPO.split("/"));
@@ -134,34 +134,6 @@ export async function createOssStore(projectName) {
     `${chalk.yellow("★")} Enjoying the lab? A star helps others find it: ${chalk.underline("https://github.com/kOaDT/oss-oopssec-store")}`
   );
   console.log();
-}
-
-function runCommand(command, args, cwd) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      stdio: "pipe",
-      shell: process.platform === "win32",
-    });
-
-    let stderr = "";
-
-    child.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(stderr || `Command failed with code ${code}`));
-      }
-    });
-
-    child.on("error", (error) => {
-      reject(error);
-    });
-  });
 }
 
 function failAndCleanup(error, targetPath) {

--- a/packages/create-oss-store/src/run-command.js
+++ b/packages/create-oss-store/src/run-command.js
@@ -1,0 +1,36 @@
+import { spawn } from "child_process";
+
+export function runCommand(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: "pipe",
+      shell: process.platform === "win32",
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(stderr || stdout || `Command failed with code ${code}`)
+        );
+      }
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+  });
+}

--- a/tests/unit/create-oss-store-run-command.test.ts
+++ b/tests/unit/create-oss-store-run-command.test.ts
@@ -1,0 +1,129 @@
+import { spawnSync } from "child_process";
+import path from "path";
+import { pathToFileURL } from "url";
+
+const runCommandUrl = pathToFileURL(
+  path.resolve(__dirname, "../../packages/create-oss-store/src/run-command.js")
+).href;
+
+function runWithRunCommand(body: string, timeout = 8000) {
+  const script = `
+    import { runCommand } from ${JSON.stringify(runCommandUrl)};
+    try {
+      ${body}
+    } catch (error) {
+      console.error(error);
+      process.exit(1);
+    }
+  `;
+  return spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    encoding: "utf8",
+    timeout,
+    killSignal: "SIGKILL",
+  });
+}
+
+describe("create-oss-store runCommand", () => {
+  it("includes stdout in the rejection when stderr is empty", () => {
+    const result = runWithRunCommand(`
+      try {
+        await runCommand(
+          process.execPath,
+          [
+            "-e",
+            "process.stdout.write('Type error: cannot compile foo.ts'); process.exit(1)",
+          ],
+          process.cwd()
+        );
+        process.stdout.write("RESOLVED");
+        process.exit(2);
+      } catch (error) {
+        process.stdout.write(error.message);
+      }
+    `);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Type error: cannot compile foo.ts");
+    expect(result.stdout).not.toContain("Command failed with code 1");
+  });
+
+  it("still prefers stderr when both streams have output", () => {
+    const result = runWithRunCommand(`
+      try {
+        await runCommand(
+          process.execPath,
+          [
+            "-e",
+            "process.stdout.write('build log'); process.stderr.write('real error'); process.exit(1)",
+          ],
+          process.cwd()
+        );
+        process.stdout.write("RESOLVED");
+        process.exit(2);
+      } catch (error) {
+        process.stdout.write(error.message);
+      }
+    `);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("real error");
+    expect(result.stdout).not.toContain("build log");
+  });
+
+  it("completes when the child writes more than 64KB to stdout", () => {
+    // Node buffers unread stdout (~64KB) on top of the OS pipe (~64KB), so
+    // 128KB can still complete. 2MB exceeds both and hangs without a consumer.
+    const result = runWithRunCommand(
+      `
+      await runCommand(
+        process.execPath,
+        ["-e", "process.stdout.write('x'.repeat(2 * 1024 * 1024))"],
+        process.cwd()
+      );
+      process.stdout.write("completed");
+    `,
+      5000
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("completed");
+  });
+
+  it("resolves when the command succeeds", () => {
+    const result = runWithRunCommand(`
+      await runCommand(
+        process.execPath,
+        ["-e", "process.exit(0)"],
+        process.cwd()
+      );
+      process.stdout.write("ok");
+    `);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("ok");
+  });
+
+  it("falls back to the exit code when both streams are empty", () => {
+    const result = runWithRunCommand(`
+      try {
+        await runCommand(
+          process.execPath,
+          ["-e", "process.exit(1)"],
+          process.cwd()
+        );
+        process.stdout.write("RESOLVED");
+        process.exit(2);
+      } catch (error) {
+        process.stdout.write(error.message);
+      }
+    `);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("Command failed with code 1");
+  });
+});


### PR DESCRIPTION
Drain child stdout in create-oss-store runCommand so failed builds surface real errors and large stdout no longer hangs. Fixes #319